### PR TITLE
Grammar bugfixes, new features, and refactoring

### DIFF
--- a/cellumata_syntax-v2/cellmata.g4
+++ b/cellumata_syntax-v2/cellmata.g4
@@ -21,7 +21,7 @@ code_block : BLOCK_START NEWLINE* (stmt NEWLINE*)* BLOCK_END ;
 stmt : (if_stmt | return_stmt | become_stmt | switch_stmt | assign_stmt | increment_stmt | decrement_stmt) ;
 
 assign_stmt : 'let'? (var_ident | array_lookup) '=' expr ';';
-if_stmt : 'if' PARAN_START expr PARAN_END code_block ('else' 'if' PARAN_START expr PARAN_END code_block)* ('else' code_block)? ;
+if_stmt : 'if' PAREN_START expr PAREN_END code_block ('else' 'if' PAREN_START expr PAREN_END code_block)* ('else' code_block)? ;
 return_stmt : STMT_RETURN expr (LIST_SEP expr)*? ';';
 become_stmt : STMT_BECOME state_ident ';' ;
 increment_stmt : var_ident OP_INCREMENT ';' | OP_INCREMENT var_ident ';';
@@ -50,12 +50,12 @@ bool_literal : LITERAL_TRUE | LITERAL_FALSE ;
 // Functions
 func_ident : IDENT ;
 func_decl : STMT_FUNC func_ident func_args_decl func_return_decl func_body ;
-func_args_decl : PARAN_START (type_ident (LIST_SEP type_ident)?)? PARAN_END ;
-func_return_decl : (PARAN_START (type_ident (LIST_SEP type_ident)?)? PARAN_END)? ;
+func_args_decl : PAREN_START (type_ident (LIST_SEP type_ident)?)? PAREN_END ;
+func_return_decl : (PAREN_START (type_ident (LIST_SEP type_ident)?)? PAREN_END)? ;
 func_body: BLOCK_START (stmt)*? BLOCK_END ;
 
 // Switch
-switch_stmt : STMT_SWITCH PARAN_START expr PARAN_END BLOCK_START switch_case* BLOCK_END;
+switch_stmt : STMT_SWITCH PAREN_START expr PAREN_END BLOCK_START switch_case* BLOCK_END;
 switch_case : ('case' expr | 'default') ':' (stmt | fallthrough_stmt)* ;
 fallthrough_stmt : STMT_FALLTHROUGH ';' ;
 
@@ -69,8 +69,8 @@ expr_5 : expr_5 OP_MORE expr_6 | expr_5 OP_MORE_EQ expr_6 | expr_5 OP_LESS expr_
 expr_6 : expr_6 OP_PLUS expr_7 | expr_6 OP_MINUS expr_7 | expr_7;
 expr_7 : expr_7 OP_MULTIPLY expr_8 | expr_7 OP_DIVIDE expr_8 | expr_8 ;
 expr_8 : OP_INCREMENT expr_9 | OP_DECREMENT expr_9 | OP_PLUS expr_9 | OP_MINUS expr_9 | OP_NOT expr_9 | expr_9 ;
-expr_9 : expr_10 OP_INCREMENT | expr_10 OP_DECREMENT | func_ident PARAN_START (expr (LIST_SEP expr)*)?  PARAN_END  | expr_10 SQ_BRACKET_START DIGITS SQ_BRACKET_END | array_value | expr_10;
-expr_10 : PARAN_START expr PARAN_END | expr_11 ;
+expr_9 : expr_10 OP_INCREMENT | expr_10 OP_DECREMENT | func_ident PAREN_START (expr (LIST_SEP expr)*)?  PAREN_END  | expr_10 SQ_BRACKET_START DIGITS SQ_BRACKET_END | array_value | expr_10;
+expr_10 : PAREN_START expr PAREN_END | expr_11 ;
 expr_11 : literal | var_ident ;
 
 // Tokens
@@ -85,8 +85,8 @@ BLOCK_START : '{' ;
 BLOCK_END : '}' ;
 SQ_BRACKET_START : '[' ;
 SQ_BRACKET_END : ']' ;
-PARAN_START : '(' ;
-PARAN_END : ')' ;
+PAREN_START : '(' ;
+PAREN_END : ')' ;
 
 OP_COMPARE : 'is' ;
 OP_NOT : 'not' ;

--- a/cellumata_syntax-v2/cellmata.g4
+++ b/cellumata_syntax-v2/cellmata.g4
@@ -1,4 +1,4 @@
-grammar test;
+grammar cellmata;
 
 start : board_decl (WHITESPACE | NEWLINE)* body EOF;
 
@@ -9,7 +9,7 @@ const_ident : IDENT ;
 // Board
 board_decl : STMT_BOARD WHITESPACE* BLOCK_START (WHITESPACE | NEWLINE)* board_world (WHITESPACE | NEWLINE)* board_tickrate (WHITESPACE | NEWLINE)* BLOCK_END ;
 board_world : 'world' WHITESPACE* ASSIGN WHITESPACE* board_world_dim (LIST_SEP WHITESPACE* board_world_dim)?;
-board_world_dim : DIGITS '[' ('wrap' | 'edge' ASSIGN IDENT) SQ_BRACKET_END | 'infinite' ;
+board_world_dim : DIGITS SQ_BRACKET_START ('wrap' | 'edge' ASSIGN IDENT) SQ_BRACKET_END | 'infinite' ;
 board_tickrate : 'tickrate' WHITESPACE* ASSIGN WHITESPACE* DIGITS ;
 
 // State
@@ -53,7 +53,7 @@ func_return_decl : (PARAN_START (type_ident (LIST_SEP type_ident)?)? PARAN_END)?
 func_body: BLOCK_START (stmt)*? BLOCK_END ;
 
 // Switch
-switch_stmt : STMT_SWITCH PARAN_START expr PARAM_END BLOCK_START switch_case* BLOCK_END;
+switch_stmt : STMT_SWITCH PARAN_START expr PARAN_END BLOCK_START switch_case* BLOCK_END;
 switch_case : ('case' expr | 'default') ':' (stmt | fallthrough_stmt)* ;
 fallthrough_stmt : STMT_FALLTHROUGH ';' ;
 
@@ -67,8 +67,8 @@ expr_5 : expr_5 OP_MORE expr_6 | expr_5 OP_MORE_EQ expr_6 | expr_5 OP_LESS expr_
 expr_6 : expr_6 OP_PLUS expr_7 | expr_6 OP_MINUS expr_7 | expr_7;
 expr_7 : expr_7 OP_MULTIPLY expr_8 | expr_7 OP_DIVIDE expr_8 | expr_8 ;
 expr_8 : OP_INCREMENT expr_9 | OP_DECREMENT expr_9 | OP_PLUS expr_9 | OP_MINUS expr_9 | OP_NOT expr_9 | expr_9 ;
-expr_9 : expr_10 OP_INCREMENT | expr_10 OP_DECREMENT | func_ident PARAN_START (expr (LIST_SEP expr)*)?  PARAM_END  | expr_10 SQ_BRACKET_START DIGITS SQ_BRACKET_END | array_value | expr_10;
-expr_10 : PARAN_START expr PARAM_END | expr_11 ;
+expr_9 : expr_10 OP_INCREMENT | expr_10 OP_DECREMENT | func_ident PARAN_START (expr (LIST_SEP expr)*)?  PARAN_END  | expr_10 SQ_BRACKET_START DIGITS SQ_BRACKET_END | array_value | expr_10;
+expr_10 : PARAN_START expr PARAN_END | expr_11 ;
 expr_11 : literal | var_ident ;
 
 // Tokens
@@ -80,9 +80,9 @@ WHITESPACE : ('\t' | ' ') -> skip ;
 BLOCK_START : '{' ;
 BLOCK_END : '}' ;
 SQ_BRACKET_START : '[' ;
-SQ_BRACKET_END : '[' ;
-PARAN_START : PARAN_START ;
-PARAM_END : PARAN_END ;
+SQ_BRACKET_END : ']' ;
+PARAN_START : '(' ;
+PARAN_END : ')' ;
 
 OP_COMPARE : 'is' ;
 OP_NOT : 'not' ;

--- a/cellumata_syntax-v2/cellmata.g4
+++ b/cellumata_syntax-v2/cellmata.g4
@@ -24,10 +24,11 @@ assign_stmt : 'let'? (var_ident | array_lookup) ASSIGN expr END;
 if_stmt : STMT_IF PAREN_START expr PAREN_END code_block (STMT_ELSE STMT_IF PAREN_START expr PAREN_END code_block)* (STMT_ELSE code_block)? ;
 return_stmt : STMT_RETURN expr (LIST_SEP expr)*? END;
 become_stmt : STMT_BECOME state_ident END ;
-increment_stmt : var_ident OP_INCREMENT ';' | OP_INCREMENT var_ident ';';
-decrement_stmt : var_ident OP_DECREMENT ';' | OP_DECREMENT var_ident ';';
+increment_stmt : modifiable_ident OP_INCREMENT ';' | OP_INCREMENT modifiable_ident ';';
+decrement_stmt : modifiable_ident OP_DECREMENT ';' | OP_DECREMENT modifiable_ident ';';
 
-ident : var_ident ;
+// Identifiers
+modifiable_ident : var_ident | array_lookup ;
 var_ident : IDENT ;
 
 // Type declaration

--- a/cellumata_syntax-v2/cellmata.g4
+++ b/cellumata_syntax-v2/cellmata.g4
@@ -78,6 +78,7 @@ LIST_SEP : ',' ;
 NEWLINE : ('\r'? '\n' | '\r') -> skip ;
 WHITESPACE : ('\t' | ' ') -> skip ;
 LINE_COMMENT : '//' ~[\r\n]* -> skip ;
+COMMENT : '/*' .*? '*/' -> skip ;
 BLOCK_START : '{' ;
 BLOCK_END : '}' ;
 SQ_BRACKET_START : '[' ;

--- a/cellumata_syntax-v2/cellmata.g4
+++ b/cellumata_syntax-v2/cellmata.g4
@@ -77,6 +77,7 @@ ASSIGN : '=' ;
 LIST_SEP : ',' ;
 NEWLINE : ('\r'? '\n' | '\r') -> skip ;
 WHITESPACE : ('\t' | ' ') -> skip ;
+LINE_COMMENT : '//' ~[\r\n]* -> skip ;
 BLOCK_START : '{' ;
 BLOCK_END : '}' ;
 SQ_BRACKET_START : '[' ;

--- a/cellumata_syntax-v2/cellmata.g4
+++ b/cellumata_syntax-v2/cellmata.g4
@@ -18,12 +18,14 @@ state_ident : IDENT ;
 
 // Code
 code_block : BLOCK_START NEWLINE* (stmt NEWLINE*)* BLOCK_END ;
-stmt : (if_stmt | return_stmt | become_stmt | switch_stmt | assign_stmt) ;
+stmt : (if_stmt | return_stmt | become_stmt | switch_stmt | assign_stmt | increment_stmt | decrement_stmt) ;
 
 assign_stmt : 'let'? (var_ident | array_lookup) '=' expr ';';
 if_stmt : 'if' PARAN_START expr PARAN_END code_block ('else' 'if' PARAN_START expr PARAN_END code_block)* ('else' code_block)? ;
 return_stmt : STMT_RETURN expr (LIST_SEP expr)*? ';';
 become_stmt : STMT_BECOME state_ident ';' ;
+increment_stmt : var_ident OP_INCREMENT ';' | OP_INCREMENT var_ident ';';
+decrement_stmt : var_ident OP_DECREMENT ';' | OP_DECREMENT var_ident ';';
 
 ident : var_ident ;
 var_ident : IDENT ;

--- a/cellumata_syntax-v2/example.cell
+++ b/cellumata_syntax-v2/example.cell
@@ -15,21 +15,3 @@ state foo {
 
     return a;
 }
-
-// example of naive CGOL ruleset syntax
-state bar {
-    let neighbours = 0;
-
-    for MooreNeighbourhood(x, y) {
-        if (this is foo) {
-            neighbours++;
-        }
-    if (neighours >= 2 and neighbours <= 4) become foo;
-}
-
-// example of enhanced CGOL ruleset syntax
-state baz {
-    let neighbours = count(MooreNeighbours(this.x, this.y), foo);
-
-    if (neighours >= 2 and neighbours <= 4) become foo;
-}

--- a/cellumata_syntax-v2/example.cell
+++ b/cellumata_syntax-v2/example.cell
@@ -24,12 +24,12 @@ state bar {
         if (this is foo) {
             neighbours++;
         }
-    if (neighours >= 2 && neighbours <= 4) become foo;
+    if (neighours >= 2 and neighbours <= 4) become foo;
 }
 
 // example of enhanced CGOL ruleset syntax
 state baz {
     let neighbours = count(MooreNeighbours(this.x, this.y), foo);
 
-    if (neighours >= 2 && neighbours <= 4) become foo;
+    if (neighours >= 2 and neighbours <= 4) become foo;
 }


### PR DESCRIPTION
Bugfixes:
- Missing definitions of `PAREN_START` and `PAREN_END` resulting in implicit left-recursion - it did compile with warnings before this fix
- Fixed literal declaration of `SQ_BRACKET_START` in `board_world_dim`-definition
- Threw out dreamcode in `example.cell` that would not easily express the same notion without much progress on grammar
- Fixed spelling mistake. The proper abbreviation for parenthesis is `PAREN` - [supposedly](https://www.allacronyms.com/parenthesis/abbreviated).

New features:
- Added grammar-definition for single-line comments with `//` followed by optionally whatever that isn't carriage- or newline-meta
- Added grammar-definition for multi-line comments with `/*` optionally whatever `*/`
- Added support for `C`-like post- and pre-fix increment and decrement. Note that previous iteration supported post-fix increment/decrement, but only as a part of an expression.

I'm not certain that the implementation of post/pre inc- and decrement is very good.

Also renamed both grammar and filename to a non-test name, just `cellmata` for now, which allows the `antlr4` intellij-plugin to test the grammar and create parse-trees from programs written in this language-syntax. Here a parse-tree for `example2.cell`, which is wildly inflated at expressions, due to current grammar-structure:
![image](https://user-images.githubusercontent.com/11318702/53685131-2c66fd80-3d17-11e9-810a-ed4e8e188651.png)
