### PR TITLE
Grammar feature expansion and tidying

### DIFF
--- a/cellumata_syntax-v2/cellmata.g4
+++ b/cellumata_syntax-v2/cellmata.g4
@@ -1,16 +1,17 @@
 grammar cellmata;
 
-start : board_decl body EOF;
+start : world_dcl body EOF;
 
 body : (state_decl | const_decl)*;
 const_decl : 'const' const_ident ASSIGN expr ;
 const_ident : IDENT ;
 
 // Board
-board_decl : STMT_BOARD BLOCK_START board_world board_tickrate BLOCK_END ;
-board_world : 'world' ASSIGN board_world_dim (LIST_SEP board_world_dim)?;
-board_world_dim : DIGITS SQ_BRACKET_START ('wrap' | 'edge' ASSIGN IDENT) SQ_BRACKET_END | 'infinite' ;
-board_tickrate : 'tickrate' ASSIGN DIGITS ;
+world_dcl : STMT_WORLD BLOCK_START world_size world_tickrate? world_cellsize? BLOCK_END ;
+world_size : 'size' ASSIGN world_size_dim (LIST_SEP world_size_dim)?;
+world_size_dim : DIGITS SQ_BRACKET_START ('wrap' | 'edge' ASSIGN IDENT) SQ_BRACKET_END | 'infinite' ;
+world_tickrate : 'tickrate' ASSIGN DIGITS ;
+world_cellsize : 'cellsize' ASSIGN DIGITS ;
 
 // State
 state_decl : STMT_STATE state_ident code_block ;
@@ -94,7 +95,7 @@ OP_OR : 'or' ;
 OP_XOR : 'xor' ;
 
 STMT_STATE : 'state' ;
-STMT_BOARD : 'board' ;
+STMT_WORLD : 'world' ;
 STMT_BECOME : 'become' ;
 STMT_IF : 'if' ;
 STMT_ELSE : 'else' ;

--- a/cellumata_syntax-v2/cellmata.g4
+++ b/cellumata_syntax-v2/cellmata.g4
@@ -2,11 +2,11 @@ grammar cellmata;
 
 start : world_dcl body EOF;
 
-body : (state_decl | const_decl)*;
+body : (state_decl | neighbourhood_decl | const_decl)*;
 const_decl : 'const' const_ident ASSIGN expr ;
 const_ident : IDENT ;
 
-// Board
+// World
 world_dcl : STMT_WORLD BLOCK_START world_size world_tickrate? world_cellsize? BLOCK_END ;
 world_size : 'size' ASSIGN world_size_dim (LIST_SEP world_size_dim)?;
 world_size_dim : DIGITS SQ_BRACKET_START ('wrap' | 'edge' ASSIGN IDENT) SQ_BRACKET_END | 'infinite' ;
@@ -26,6 +26,13 @@ if_stmt : STMT_IF PAREN_START expr PAREN_END code_block (STMT_ELSE STMT_IF PAREN
 become_stmt : STMT_BECOME state_ident END ;
 increment_stmt : modifiable_ident OP_INCREMENT ';' | OP_INCREMENT modifiable_ident ';';
 decrement_stmt : modifiable_ident OP_DECREMENT ';' | OP_DECREMENT modifiable_ident ';';
+
+// Neighbourhood
+neighbourhood_decl : STMT_NEIGHBOUR neighbourhood_code ;
+
+// Neighbourhood declaration
+neighbourhood_code : BLOCK_START coords_decl (LIST_SEP coords_decl)* BLOCK_END ;
+coords_decl : PAREN_START DIGITS (LIST_SEP DIGITS)? PAREN_END ;
 
 // Identifiers
 modifiable_ident : var_ident | array_lookup ;
@@ -62,7 +69,7 @@ expr_10 : PAREN_START expr PAREN_END | expr_11 ;
 expr_11 : literal | var_ident ;
 
 // Tokens
-DIGITS : [1-9][0-9]* | [0] ;
+DIGITS : '-'? [1-9][0-9]* | [0] ;
 ASSIGN : '=' ;
 LIST_SEP : ',' ;
 NEWLINE : ('\r'? '\n' | '\r') -> skip ;
@@ -96,6 +103,7 @@ OP_XOR : 'xor' ;
 
 STMT_STATE : 'state' ;
 STMT_WORLD : 'world' ;
+STMT_NEIGHBOUR : 'neighbours' ;
 STMT_BECOME : 'become' ;
 STMT_IF : 'if' ;
 STMT_ELSE : 'else' ;

--- a/cellumata_syntax-v2/cellmata.g4
+++ b/cellumata_syntax-v2/cellmata.g4
@@ -22,14 +22,15 @@ state_rgb : PAREN_START (DIGITS LIST_SEP DIGITS LIST_SEP DIGITS) PAREN_END ;
 code_block : BLOCK_START stmt* BLOCK_END ;
 stmt : (if_stmt | become_stmt | assign_stmt | increment_stmt | decrement_stmt) ;
 
-assign_stmt : 'let'? (var_ident | array_lookup) ASSIGN expr END;
+assign_stmt : 'let'? (var_ident | array_lookup) ASSIGN expr END ;
 if_stmt : STMT_IF PAREN_START expr PAREN_END code_block (STMT_ELSE STMT_IF PAREN_START expr PAREN_END code_block)* (STMT_ELSE code_block)? ;
 become_stmt : STMT_BECOME state_ident END ;
 increment_stmt : modifiable_ident OP_INCREMENT ';' | OP_INCREMENT modifiable_ident ';';
 decrement_stmt : modifiable_ident OP_DECREMENT ';' | OP_DECREMENT modifiable_ident ';';
 
 // Neighbourhood
-neighbourhood_decl : STMT_NEIGHBOUR neighbourhood_code ;
+neighbourhood_decl : STMT_NEIGHBOUR neighbourhood_ident neighbourhood_code ;
+neighbourhood_ident : IDENT ;
 
 // Neighbourhood declaration
 neighbourhood_code : BLOCK_START coords_decl (LIST_SEP coords_decl)* BLOCK_END ;
@@ -67,7 +68,12 @@ expr_7 : expr_7 OP_MULTIPLY expr_8 | expr_7 OP_DIVIDE expr_8 | expr_8 ;
 expr_8 : OP_INCREMENT expr_9 | OP_DECREMENT expr_9 | OP_PLUS expr_9 | OP_MINUS expr_9 | OP_NOT expr_9 | expr_9 ;
 expr_9 : expr_10 OP_INCREMENT | expr_10 OP_DECREMENT | expr_10 SQ_BRACKET_START DIGITS SQ_BRACKET_END | array_value | expr_10;
 expr_10 : PAREN_START expr PAREN_END | expr_11 ;
-expr_11 : literal | var_ident ;
+expr_11 : literal | var_ident | func ;
+
+// Built-in funcitons
+func : (func_count | func_rand) ;
+func_count : FUNC_COUNT PAREN_START neighbourhood_ident LIST_SEP state_ident PAREN_END ;
+func_rand : FUNC_RAND PAREN_START DIGITS PAREN_END ;
 
 // Tokens
 DIGITS : '-'? [1-9][0-9]* | [0] ;
@@ -103,11 +109,14 @@ OP_OR : 'or' ;
 OP_XOR : 'xor' ;
 
 STMT_STATE : 'state' ;
+STMT_NEIGHBOUR : 'neighbourhood' ;
 STMT_WORLD : 'world' ;
-STMT_NEIGHBOUR : 'neighbours' ;
 STMT_BECOME : 'become' ;
 STMT_IF : 'if' ;
 STMT_ELSE : 'else' ;
+
+FUNC_COUNT : 'count' ;
+FUNC_RAND :  'rand' ;
 
 TYPE_NUMBER : 'number' ;
 TYPE_BOOLEAN : 'boolean' | 'bool' ;
@@ -115,4 +124,4 @@ TYPE_BOOLEAN : 'boolean' | 'bool' ;
 LITERAL_TRUE : 'true' ;
 LITERAL_FALSE : 'false' ;
 
-IDENT : [a-zA-Z] ([a-zA-Z0-9]+)? ;
+IDENT : [a-zA-Z]([a-zA-Z0-9]+)? ;

--- a/cellumata_syntax-v2/cellmata.g4
+++ b/cellumata_syntax-v2/cellmata.g4
@@ -14,8 +14,9 @@ world_tickrate : 'tickrate' ASSIGN DIGITS ;
 world_cellsize : 'cellsize' ASSIGN DIGITS ;
 
 // State
-state_decl : STMT_STATE state_ident code_block ;
+state_decl : STMT_STATE state_ident state_rgb code_block ;
 state_ident : IDENT ;
+state_rgb : PAREN_START (DIGITS LIST_SEP DIGITS LIST_SEP DIGITS) PAREN_END ;
 
 // Code
 code_block : BLOCK_START stmt* BLOCK_END ;

--- a/cellumata_syntax-v2/cellmata.g4
+++ b/cellumata_syntax-v2/cellmata.g4
@@ -2,7 +2,7 @@ grammar cellmata;
 
 start : board_decl (WHITESPACE | NEWLINE)* body EOF;
 
-body : ((state_decl | const_decl | func_decl) NEWLINE*)*;
+body : ((state_decl | const_decl) NEWLINE*)*;
 const_decl : 'const' const_ident ASSIGN expr ;
 const_ident : IDENT ;
 
@@ -18,11 +18,10 @@ state_ident : IDENT ;
 
 // Code
 code_block : BLOCK_START NEWLINE* (stmt NEWLINE*)* BLOCK_END ;
-stmt : (if_stmt | return_stmt | become_stmt | assign_stmt | increment_stmt | decrement_stmt) ;
+stmt : (if_stmt | become_stmt | assign_stmt | increment_stmt | decrement_stmt) ;
 
 assign_stmt : 'let'? (var_ident | array_lookup) ASSIGN expr END;
 if_stmt : STMT_IF PAREN_START expr PAREN_END code_block (STMT_ELSE STMT_IF PAREN_START expr PAREN_END code_block)* (STMT_ELSE code_block)? ;
-return_stmt : STMT_RETURN expr (LIST_SEP expr)*? END;
 become_stmt : STMT_BECOME state_ident END ;
 increment_stmt : modifiable_ident OP_INCREMENT ';' | OP_INCREMENT modifiable_ident ';';
 decrement_stmt : modifiable_ident OP_DECREMENT ';' | OP_DECREMENT modifiable_ident ';';
@@ -47,13 +46,6 @@ literal : number_literal | bool_literal ;
 number_literal : DIGITS ;
 bool_literal : LITERAL_TRUE | LITERAL_FALSE ;
 
-// Functions
-func_ident : IDENT ;
-func_decl : STMT_FUNC func_ident func_args_decl func_return_decl func_body ;
-func_args_decl : PAREN_START (type_ident (LIST_SEP type_ident)?)? PAREN_END ;
-func_return_decl : (PAREN_START (type_ident (LIST_SEP type_ident)?)? PAREN_END)? ;
-func_body: BLOCK_START (stmt)*? BLOCK_END ;
-
 // Math
 expr : expr_1 ;
 expr_1 : expr_1 OP_XOR expr_2 | expr_2 ;
@@ -64,7 +56,7 @@ expr_5 : expr_5 OP_MORE expr_6 | expr_5 OP_MORE_EQ expr_6 | expr_5 OP_LESS expr_
 expr_6 : expr_6 OP_PLUS expr_7 | expr_6 OP_MINUS expr_7 | expr_7;
 expr_7 : expr_7 OP_MULTIPLY expr_8 | expr_7 OP_DIVIDE expr_8 | expr_8 ;
 expr_8 : OP_INCREMENT expr_9 | OP_DECREMENT expr_9 | OP_PLUS expr_9 | OP_MINUS expr_9 | OP_NOT expr_9 | expr_9 ;
-expr_9 : expr_10 OP_INCREMENT | expr_10 OP_DECREMENT | func_ident PAREN_START (expr (LIST_SEP expr)*)?  PAREN_END  | expr_10 SQ_BRACKET_START DIGITS SQ_BRACKET_END | array_value | expr_10;
+expr_9 : expr_10 OP_INCREMENT | expr_10 OP_DECREMENT | expr_10 SQ_BRACKET_START DIGITS SQ_BRACKET_END | array_value | expr_10;
 expr_10 : PAREN_START expr PAREN_END | expr_11 ;
 expr_11 : literal | var_ident ;
 
@@ -101,10 +93,8 @@ OP_AND : 'and' ;
 OP_OR : 'or' ;
 OP_XOR : 'xor' ;
 
-STMT_FUNC : 'func' ;
 STMT_STATE : 'state' ;
 STMT_BOARD : 'board' ;
-STMT_RETURN : 'return' ;
 STMT_BECOME : 'become' ;
 STMT_IF : 'if' ;
 STMT_ELSE : 'else' ;

--- a/cellumata_syntax-v2/cellmata.g4
+++ b/cellumata_syntax-v2/cellmata.g4
@@ -1,23 +1,23 @@
 grammar cellmata;
 
-start : board_decl (WHITESPACE | NEWLINE)* body EOF;
+start : board_decl body EOF;
 
-body : ((state_decl | const_decl) NEWLINE*)*;
+body : (state_decl | const_decl)*;
 const_decl : 'const' const_ident ASSIGN expr ;
 const_ident : IDENT ;
 
 // Board
-board_decl : STMT_BOARD WHITESPACE* BLOCK_START (WHITESPACE | NEWLINE)* board_world (WHITESPACE | NEWLINE)* board_tickrate (WHITESPACE | NEWLINE)* BLOCK_END ;
-board_world : 'world' WHITESPACE* ASSIGN WHITESPACE* board_world_dim (LIST_SEP WHITESPACE* board_world_dim)?;
+board_decl : STMT_BOARD BLOCK_START board_world board_tickrate BLOCK_END ;
+board_world : 'world' ASSIGN board_world_dim (LIST_SEP board_world_dim)?;
 board_world_dim : DIGITS SQ_BRACKET_START ('wrap' | 'edge' ASSIGN IDENT) SQ_BRACKET_END | 'infinite' ;
-board_tickrate : 'tickrate' WHITESPACE* ASSIGN WHITESPACE* DIGITS ;
+board_tickrate : 'tickrate' ASSIGN DIGITS ;
 
 // State
 state_decl : STMT_STATE state_ident code_block ;
 state_ident : IDENT ;
 
 // Code
-code_block : BLOCK_START NEWLINE* (stmt NEWLINE*)* BLOCK_END ;
+code_block : BLOCK_START stmt* BLOCK_END ;
 stmt : (if_stmt | become_stmt | assign_stmt | increment_stmt | decrement_stmt) ;
 
 assign_stmt : 'let'? (var_ident | array_lookup) ASSIGN expr END;

--- a/cellumata_syntax-v2/cellmata.g4
+++ b/cellumata_syntax-v2/cellmata.g4
@@ -18,7 +18,7 @@ state_ident : IDENT ;
 
 // Code
 code_block : BLOCK_START NEWLINE* (stmt NEWLINE*)* BLOCK_END ;
-stmt : (if_stmt | return_stmt | become_stmt | switch_stmt | assign_stmt | increment_stmt | decrement_stmt) ;
+stmt : (if_stmt | return_stmt | become_stmt | assign_stmt | increment_stmt | decrement_stmt) ;
 
 assign_stmt : 'let'? (var_ident | array_lookup) ASSIGN expr END;
 if_stmt : STMT_IF PAREN_START expr PAREN_END code_block (STMT_ELSE STMT_IF PAREN_START expr PAREN_END code_block)* (STMT_ELSE code_block)? ;
@@ -53,11 +53,6 @@ func_decl : STMT_FUNC func_ident func_args_decl func_return_decl func_body ;
 func_args_decl : PAREN_START (type_ident (LIST_SEP type_ident)?)? PAREN_END ;
 func_return_decl : (PAREN_START (type_ident (LIST_SEP type_ident)?)? PAREN_END)? ;
 func_body: BLOCK_START (stmt)*? BLOCK_END ;
-
-// Switch
-switch_stmt : STMT_SWITCH PAREN_START expr PAREN_END BLOCK_START switch_case* BLOCK_END;
-switch_case : (STMT_CASE expr | STMT_DEFAULT) ':' (stmt | fallthrough_stmt)* ;
-fallthrough_stmt : STMT_FALLTHROUGH END ;
 
 // Math
 expr : expr_1 ;
@@ -106,10 +101,6 @@ OP_AND : 'and' ;
 OP_OR : 'or' ;
 OP_XOR : 'xor' ;
 
-STMT_FALLTHROUGH : 'fallthrough' ;
-STMT_SWITCH : 'switch' ;
-STMT_CASE : 'case' ;
-STMT_DEFAULT : 'default' ;
 STMT_FUNC : 'func' ;
 STMT_STATE : 'state' ;
 STMT_BOARD : 'board' ;

--- a/cellumata_syntax-v2/cgol.cell
+++ b/cellumata_syntax-v2/cgol.cell
@@ -3,6 +3,7 @@
 world {
     size = 100 W, 100 W
     tickrate = 8
+    cellsize = 4
 }
 
 neighbours {

--- a/cellumata_syntax-v2/cgol.cell
+++ b/cellumata_syntax-v2/cgol.cell
@@ -7,7 +7,7 @@ world {
 }
 
 // custom definition of neighbours, like below, is not yet recognised by the grammar
-neighbours Moore {
+neighbourhood Moore {
     (-1, 1), (0, 1), (1, 1),
     (-1, 0),          (1, 0),
     (-1, -1), (0, -1), (1, -1)

--- a/cellumata_syntax-v2/cgol.cell
+++ b/cellumata_syntax-v2/cgol.cell
@@ -1,11 +1,12 @@
 // Conway's game of life
 
 world {
-    size = 100 W, 100 W
+    size = 100[edge=w], 100[edge=w]
     tickrate = 8
     cellsize = 4
 }
 
+// custom definition of neighbours, like below, is not yet recognised by the grammar
 neighbours {
     (-1, 1), (0, 1), (1, 1),
     (-1, 0),          (1, 0),

--- a/cellumata_syntax-v2/cgol.cell
+++ b/cellumata_syntax-v2/cgol.cell
@@ -2,7 +2,6 @@
 
 world {
     size = 100 W, 100 W
-    cellsize = 8
     tickrate = 8
 }
 

--- a/cellumata_syntax-v2/cgol.cell
+++ b/cellumata_syntax-v2/cgol.cell
@@ -7,17 +7,21 @@ world {
 }
 
 // custom definition of neighbours, like below, is not yet recognised by the grammar
-neighbours {
+neighbours Moore {
     (-1, 1), (0, 1), (1, 1),
     (-1, 0),          (1, 0),
     (-1, -1), (0, -1), (1, -1)
 }
 
 state Dead (255, 255, 255) {
-    if (count(neighbours, Alive) == 3) become Alive
+    if (count(Moore, Alive) is 3) {
+        become Alive;
+    }
 }
 
 state Alive (0, 0, 0) {
-    int aliveNeighbours = count(neighbours, Alive)
-    if (aliveNeighbours < 2 or 3 < aliveNeighbours) become Dead
+    let aliveNeighbours = count(Moore, Alive);
+    if (aliveNeighbours < 2 or 3 < aliveNeighbours) {
+        become Dead;
+    }
 }

--- a/cellumata_syntax-v2/example.cell
+++ b/cellumata_syntax-v2/example.cell
@@ -9,9 +9,9 @@ state foo {
     if (23) {
         let b = 3;
         if (not b) {
-            return b;
+            become foo;
         }
     }
 
-    return a;
+    become bar;
 }

--- a/cellumata_syntax-v2/example.cell
+++ b/cellumata_syntax-v2/example.cell
@@ -3,7 +3,7 @@ world {
     tickrate = 120
 }
 
-state foo {
+state foo (0, 0, 0) {
     let a = (not (2 - 3) / (4)) is 2;
 
     if (23) {

--- a/cellumata_syntax-v2/example.cell
+++ b/cellumata_syntax-v2/example.cell
@@ -1,5 +1,5 @@
-board {
-    world = 10[edge=foo], infinite
+world {
+    size = 10[edge=foo], infinite
     tickrate = 120
 }
 

--- a/cellumata_syntax-v2/example2.cell
+++ b/cellumata_syntax-v2/example2.cell
@@ -8,35 +8,17 @@ const baz = [2]bool{ true, false }
 state foo {
     let a = (not (2 - 3) / (4)) is 2;
 
+    baz[0] = baz[1] - 2;
+
     if (23) {
         let b = 3;
         if (not b) {
-            return b;
-        } else { return a-x;}
+            become foo;
+        } else { become bar;}
     } else if (false) {
-        become bar;
-    } else {
         become baz;
+    } else {
+        become foobar;
     }
-
-    switch (getRel(1,1)) {
-        case foo:
-            a = 1;
-        case bar:
-            a = 2;
-            fallthrough;
-        case baz:
-            b = 27;
-        default:
-            a = 0;
-            b = 0;
-    }
-
-    baz[0] = baz[1] - 2;
-
-    return a;
 }
 
-func thisisfunc(number, [3]float) (number, number) {
-    return a, b;
-}

--- a/cellumata_syntax-v2/example2.cell
+++ b/cellumata_syntax-v2/example2.cell
@@ -5,7 +5,7 @@ world {
 
 const baz = [2]bool{ true, false }
 
-state foo {
+state foo (0, 0, 0) {
     let a = (not (2 - 3) / (4)) is 2;
 
     baz[0] = baz[1] - 2;

--- a/cellumata_syntax-v2/example2.cell
+++ b/cellumata_syntax-v2/example2.cell
@@ -1,5 +1,5 @@
-board {
-    world = 10[edge=foo], infinite
+world {
+    size = 10[edge=foo], infinite
     tickrate = 120
 }
 


### PR DESCRIPTION
Refactored `switch` and `func` declarations from grammar. Also renamed `board` to `world`, both as syntax and internally in grammar definition.

Also added support for custom neighbourhood definitions, RGB-notation of colour for each state, and two built-in functions; `count(neighbourhood, state)` and `rand(max)`.

- `example.cell` has been revised to conform to the new grammar, by removing return-statement
- `example2.cell` has been revised to conform to the new grammar, by removing function-, return-, and switch-usage
- `cgol.cell` Note that custom neighbourhoods are yet to be defined by the grammar.