### PR TITLE
Updated expression syntax in accordance with the abstract syntax

### DIFF
--- a/parser/cellmata.g4
+++ b/parser/cellmata.g4
@@ -162,7 +162,7 @@ PAREN_END : ')' ;
 END : ';' ;
 
 OP_COMPARE : '==' ;
-OP_COMPARE_not : '!=' ;
+OP_COMPARE_NOT : '!=' ;
 OP_NOT : '!' ;
 OP_INCREMENT : '++' ;
 OP_DECREMENT : '--' ;

--- a/parser/cellmata.g4
+++ b/parser/cellmata.g4
@@ -83,11 +83,7 @@ bool_literal
     ;
 
 // Math
-expr : expr_1 ;
-expr_1
-    : expr_1 OP_XOR expr_2 # xorExpr
-    | expr_2 # expr2Cont
-    ;
+expr : expr_2 ;
 expr_2
     : expr_2 OP_OR expr_3 # orExpr
     | expr_3 #expr3Cont
@@ -97,7 +93,7 @@ expr_3
     | expr_4 # expr4Cont
     ;
 expr_4
-    : expr_4 OP_COMPARE OP_NOT expr_5 # notEqExpr
+    : expr_4 OP_COMPARE_NOT expr_5 # notEqExpr
     | expr_4 OP_COMPARE expr_5 # eqExpr
     | expr_5 # expr5Cont
     ;
@@ -165,8 +161,9 @@ PAREN_START : '(' ;
 PAREN_END : ')' ;
 END : ';' ;
 
-OP_COMPARE : 'is' ;
-OP_NOT : 'not' ;
+OP_COMPARE : '==' ;
+OP_COMPARE_not : '!=' ;
+OP_NOT : '!' ;
 OP_INCREMENT : '++' ;
 OP_DECREMENT : '--' ;
 OP_PLUS : '+' ;
@@ -178,9 +175,8 @@ OP_LESS : '<' ;
 OP_LESS_EQ : '<=' ;
 OP_MORE : '>' ;
 OP_MORE_EQ : '>=' ;
-OP_AND : 'and' ;
-OP_OR : 'or' ;
-OP_XOR : 'xor' ;
+OP_AND : '&&' ;
+OP_OR : '||' ;
 
 WORLD_SIZE : 'size' ;
 WORLD_WRAP : 'wrap' ;


### PR DESCRIPTION
In accordance with the abstract syntax the following have been change:

- Removed xor operator
- Changed the inequality operator from `is not` to `!=`
- Changed the equality operator from `is` to `==`
- Changed the inversion operator from `not` to `!`
- Changed the and operator from `and` to `&&`
- Changed the or operator from `or` to `||` 