### PR TITLE
Removed tokens for built in functions

### DIFF
--- a/compiler/src/main/antlr/Cellmata.g4
+++ b/compiler/src/main/antlr/Cellmata.g4
@@ -198,10 +198,6 @@ STMT_ELSE : 'else' ;
 STMT_FUNC : 'function' ;
 STMT_RETURN : 'return' ;
 
-FUNC_COUNT : 'count' ;
-FUNC_RAND : 'rand' ;
-FUNC_ABS : 'abs' ;
-
 TYPE_NUMBER : 'number' ;
 TYPE_BOOLEAN : 'boolean' | 'bool' ;
 


### PR DESCRIPTION
This resolves #19, as these tokens are no longer grabbed by tokens and unable to be matched as an ident.