### PR TITLE
Implemented support for state and neighbourhoods as types

### DIFF
--- a/compiler/src/main/antlr/Cellmata.g4
+++ b/compiler/src/main/antlr/Cellmata.g4
@@ -62,7 +62,9 @@ type_ident : IDENT | type_spec ;
 type_spec
     : array_decl # typeArray
     | TYPE_BOOLEAN # typeBoolean
-    | TYPE_NUMBER # tyopeNumber
+    | TYPE_NUMBER # typeNumber
+    | STMT_NEIGHBOUR # typeNeighbour
+    | STMT_STATE # typeState
     ;
 
 // Array


### PR DESCRIPTION
Implemented support for state and neighbourhoods as types to function parameters, by modifying `type_spec` production to include the `STMT_*` tokens for state and neighbourhoods.

Also fixed minor typo: `tyopeNumber`.