### PR TITLE
Revised syntactically-correct.cell

### DIFF
--- a/parser/syntax_testing/syntactically-correct.cell
+++ b/parser/syntax_testing/syntactically-correct.cell
@@ -14,6 +14,21 @@ neighbourhood foobar {
     (-2,-2), (-1,-2), (0,-2), (1,-2), (2,-2)
 }
 
+/* This state has a 
+long, multi-line
+comment */
+state foo (255, 0, 0) {
+    let a = (not (2 - 3) / (4)) is 2;
+
+    if (23) {
+        let b = 3;
+        if (not b) {
+            become foo;
+        }
+    }
+    become bar;
+}
+
 state bar (255,255,255) {
     // multiple stmts in if-stmt code-block
     if (count(foobar, foo) >= 2) {
@@ -27,7 +42,7 @@ state bar (255,255,255) {
 }
 
 function func (neighbourhood foo, state bar) state {
-    if (func2(foobar)) {
+    if (func(foobar)) {
         return bar;
     }
 }

--- a/parser/syntax_testing/syntactically-correct.cell
+++ b/parser/syntax_testing/syntactically-correct.cell
@@ -14,27 +14,21 @@ neighbourhood foobar {
     (-2,-2), (-1,-2), (0,-2), (1,-2), (2,-2)
 }
 
-/* This state has a 
-long, multi-line
-comment */
-state foo (255, 0, 0) {
-    let a = (not (2 - 3) / (4)) is 2;
-
-    if (23) {
-        let b = 3;
-        if (not b) {
-            become foo;
-        }
-    }
-    become bar;
-}
-
 state bar (255,255,255) {
     // multiple stmts in if-stmt code-block
     if (count(foobar, foo) >= 2) {
-        let x = 
+        let x = 3.33;
         become bar;
     }
     // single stmt after if-stmt
-    if (count(foobar, foo) is 2) become foo;   
+    if (func(foobar, foo) == 2) {
+        become foo;
+    }
 }
+
+function func (neighbourhood foo, state bar) state {
+    if (func2(foobar)) {
+        return bar;
+    }
+}
+


### PR DESCRIPTION
- Now uses floats as numbers. This is dependent on #17.
- Defines a function which takes a `neighbourhood` and a `state` as parameters. This is dependent on #23.
- Fixed missing curly-brackets around if-statement body.

Does not utilise all grammar facilities.