### PR TITLE
Fixed compilation not depending on grammar generation

### DIFF
--- a/compiler/build.gradle
+++ b/compiler/build.gradle
@@ -16,9 +16,12 @@ dependencies {
 }
 
 compileKotlin {
+    dependsOn generateGrammarSource
     kotlinOptions.jvmTarget = "1.8"
 }
+
 compileTestKotlin {
+    dependsOn generateGrammarSource
     kotlinOptions.jvmTarget = "1.8"
 }
 


### PR DESCRIPTION
Added the generateGrammarSource task as prerequisite to the compileKotlin and
compileTestKotlin tasks