### PR TITLE
Fixed package naming scheme

### DIFF
--- a/compiler/build.gradle
+++ b/compiler/build.gradle
@@ -28,8 +28,8 @@ compileTestKotlin {
 
 generateGrammarSource {
     maxHeapSize = "64m"
-    arguments += ["-visitor", "-long-messages", "-package", "cs.aau.dk.d409f19.antlr"]
-    outputDirectory = file("${project.buildDir}/generated-src/antlr/main/cs/aau/dk/d409f19/antlr")
+    arguments += ["-visitor", "-long-messages", "-package", "dk.aau.cs.d409f19.antlr"]
+    outputDirectory = file("${project.buildDir}/generated-src/antlr/main/dk/aau/cs/d409f19/antlr")
 }
 
 test {

--- a/compiler/src/main/kotlin/ast/ast.kt
+++ b/compiler/src/main/kotlin/ast/ast.kt
@@ -1,6 +1,6 @@
 package dk.aau.cs.d409f19.cellumata.ast
 
-import cs.aau.dk.d409f19.antlr.CellmataParser
+import dk.aau.cs.d409f19.antlr.CellmataParser
 import org.antlr.v4.runtime.tree.ParseTree
 
 /**

--- a/compiler/src/main/kotlin/ast/mapper.kt
+++ b/compiler/src/main/kotlin/ast/mapper.kt
@@ -1,6 +1,6 @@
 package dk.aau.cs.d409f19.cellumata.ast
 
-import cs.aau.dk.d409f19.antlr.CellmataParser
+import dk.aau.cs.d409f19.antlr.CellmataParser
 import org.antlr.v4.runtime.tree.ParseTree
 import org.antlr.v4.runtime.tree.TerminalNode
 

--- a/compiler/src/main/kotlin/main.kt
+++ b/compiler/src/main/kotlin/main.kt
@@ -1,6 +1,6 @@
 package dk.aau.cs.d409f19.cellumata
 
-import cs.aau.dk.d409f19.antlr.*
+import dk.aau.cs.d409f19.antlr.*
 import dk.aau.cs.d409f19.cellumata.ast.visit
 import org.antlr.v4.runtime.ANTLRFileStream
 import org.antlr.v4.runtime.CommonTokenStream

--- a/compiler/src/test/kotlin/test.kt
+++ b/compiler/src/test/kotlin/test.kt
@@ -1,7 +1,7 @@
-package cs.aau.dk.d409f19
+package dk.aau.cs.d409f19
 
-import cs.aau.dk.d409f19.antlr.CellmataLexer
-import cs.aau.dk.d409f19.antlr.CellmataParser
+import dk.aau.cs.d409f19.antlr.CellmataLexer
+import dk.aau.cs.d409f19.antlr.CellmataParser
 import dk.aau.cs.d409f19.cellumata.ast.visit
 import org.antlr.v4.runtime.ANTLRFileStream
 import org.antlr.v4.runtime.CommonTokenStream


### PR DESCRIPTION
Package naming was inconsistent, using `cs.aau.dk` in some places, and `dk.aau.cs` in other places. 
Now everywhere is using `dk.aau.cs`.