### PR TITLE
Added mapping for for-loop, break, and continue statements

### DIFF
--- a/compiler/src/main/antlr/Cellmata.g4
+++ b/compiler/src/main/antlr/Cellmata.g4
@@ -52,10 +52,10 @@ decrement_stmt
 return_stmt : STMT_RETURN expr END ;
 
 //For-loop
-for_stmt : STMT_FOR PAREN_START for_variable? END for_condition END for_increment? PAREN_END code_block ;
-for_variable : assignment ;
+for_stmt : STMT_FOR PAREN_START for_init? END for_condition END for_post_iteration? PAREN_END code_block ;
+for_init : assignment ;
 for_condition : expr ;
-for_increment : expr | assignment ;
+for_post_iteration : assignment ;
 
 // Neighbourhood
 neighbourhood_decl : STMT_NEIGHBOUR neighbourhood_ident neighbourhood_code ;

--- a/compiler/src/main/antlr/Cellmata.g4
+++ b/compiler/src/main/antlr/Cellmata.g4
@@ -30,7 +30,7 @@ state_rgb : PAREN_START red=integer_literal LIST_SEP green=integer_literal LIST_
 
 // Code
 code_block : BLOCK_START stmt* BLOCK_END ;
-stmt : (if_stmt | become_stmt | assign_stmt | increment_stmt | decrement_stmt | return_stmt | for_stmt) ;
+stmt : (if_stmt | become_stmt | assign_stmt | increment_stmt | decrement_stmt | return_stmt | for_stmt | break_stmt | continue_stmt) ;
 
 assign_stmt : assignment END ;
 assignment : STMT_LET? (var_ident | array_lookup) ASSIGN expr ;
@@ -56,6 +56,8 @@ for_stmt : STMT_FOR PAREN_START for_init? END for_condition END for_post_iterati
 for_init : assignment ;
 for_condition : expr ;
 for_post_iteration : assignment ;
+continue_stmt : STMT_CONTINUE END ;
+break_stmt : STMT_BREAK END ;
 
 // Neighbourhood
 neighbourhood_decl : STMT_NEIGHBOUR neighbourhood_ident neighbourhood_code ;
@@ -192,6 +194,8 @@ STMT_ELSE : 'else' ;
 STMT_FUNC : 'function' ;
 STMT_RETURN : 'return' ;
 STMT_FOR : 'for' ;
+STMT_BREAK : 'break' ;
+STMT_CONTINUE : 'continue' ;
 
 TYPE_NUMBER : 'number' ;
 TYPE_BOOLEAN : 'boolean' | 'bool' ;

--- a/compiler/src/main/kotlin/ast/ast.kt
+++ b/compiler/src/main/kotlin/ast/ast.kt
@@ -134,11 +134,13 @@ data class FuncDecl(
  */
 sealed class Stmt : AST()
 
-data class AssignStmt(val ctx: CellmataParser.Assign_stmtContext, var ident: String = MAGIC_UNDEFINED_STRING, val expr: Expr) : Stmt()
+data class AssignStmt(val ctx: CellmataParser.AssignmentContext, var ident: String = MAGIC_UNDEFINED_STRING, val expr: Expr) : Stmt()
 
 data class ConditionalBlock(val ctx: ParseTree, val expr: Expr, val block: List<Stmt>)
 
 data class IfStmt(val ctx: CellmataParser.If_stmtContext, val conditionals: List<ConditionalBlock>, val elseBlock: List<Stmt>?) : Stmt()
+
+data class ForStmt(val ctx: CellmataParser.For_stmtContext, val initPart: AssignStmt, val condition: Expr, val postIterationPart: AssignStmt) : Stmt()
 
 data class BecomeStmt(val ctx: CellmataParser.Become_stmtContext, val state: Expr) : Stmt()
 

--- a/compiler/src/main/kotlin/ast/ast.kt
+++ b/compiler/src/main/kotlin/ast/ast.kt
@@ -142,6 +142,10 @@ data class IfStmt(val ctx: CellmataParser.If_stmtContext, val conditionals: List
 
 data class ForStmt(val ctx: CellmataParser.For_stmtContext, val initPart: AssignStmt, val condition: Expr, val postIterationPart: AssignStmt) : Stmt()
 
+data class BreakStmt(val ctx: CellmataParser.Break_stmtContext) : Stmt()
+
+data class ContinueStmt(val ctx: CellmataParser.Continue_stmtContext) : Stmt()
+
 data class BecomeStmt(val ctx: CellmataParser.Become_stmtContext, val state: Expr) : Stmt()
 
 data class PreIncStmt(val ctx: CellmataParser.PreIncStmtContext, val variable: Expr) : Stmt()

--- a/compiler/src/main/kotlin/ast/mapper.kt
+++ b/compiler/src/main/kotlin/ast/mapper.kt
@@ -170,6 +170,8 @@ private fun visitStmt(node: ParseTree): Stmt {
             condition = visitExpr(node.for_condition().expr()),
             postIterationPart = AssignStmt(node.for_post_iteration().assignment(), expr = visitExpr(node.for_post_iteration().assignment().expr()))
         )
+        is CellmataParser.Break_stmtContext -> BreakStmt(ctx = node)
+        is CellmataParser.Continue_stmtContext -> ContinueStmt(ctx = node)
         is CellmataParser.Become_stmtContext -> BecomeStmt(ctx = node, state = visitExpr(node.state))
         is CellmataParser.PreIncStmtContext -> PreIncStmt(ctx = node, variable = visitExpr(node.modifiable_ident()))
         is CellmataParser.PostIncStmtContext -> PostIncStmt(ctx = node, variable = visitExpr(node.modifiable_ident()))

--- a/compiler/src/main/kotlin/ast/mapper.kt
+++ b/compiler/src/main/kotlin/ast/mapper.kt
@@ -1,7 +1,6 @@
 package dk.aau.cs.d409f19.cellumata.ast
 
 import cs.aau.dk.d409f19.antlr.CellmataParser
-import javafx.scene.control.Cell
 import org.antlr.v4.runtime.tree.ParseTree
 import org.antlr.v4.runtime.tree.TerminalNode
 


### PR DESCRIPTION
I had to remove `expr` as valid post-iteration grammar, since we can only have either expressions or statements, so I chose the strict option of only allowing assign statements.

Resolves #44 and resolves #43 