### PR TITLE
Simple error system for handling minor and major errors and printing details to console.

### DIFF
--- a/compiler/src/main/kotlin/ast/ast.kt
+++ b/compiler/src/main/kotlin/ast/ast.kt
@@ -11,7 +11,7 @@ const val MAGIC_UNDEFINED_STRING = "<<THIS IS A MAGIC STRING, UNDEFINED>>"
 
 sealed class AST(open val ctx: ParserRuleContext)
 
-data class RootNode constructor(
+data class RootNode(
     override val ctx: ParserRuleContext,
     val world: WorldNode,
     val body: List<Decl>
@@ -168,7 +168,7 @@ data class PostDecStmt(override val ctx: CellmataParser.PostDecStmtContext, val 
 data class ReturnStmt(override val ctx: CellmataParser.Return_stmtContext, val value: Expr) : Stmt(ctx)
 
 /*
- * Error nodes are used when something goes wrong in mapper.kt and is returned by the failing function.
+ * Error nodes are used when something goes wrong in reduce.kt and is returned by the failing function.
  */
 class ErrorAST(override val ctx: ParserRuleContext) : AST(ctx)
 class ErrorDecl(override val ctx: ParserRuleContext) : Decl(ctx)

--- a/compiler/src/main/kotlin/ast/ast.kt
+++ b/compiler/src/main/kotlin/ast/ast.kt
@@ -1,7 +1,7 @@
 package dk.aau.cs.d409f19.cellumata.ast
 
 import dk.aau.cs.d409f19.antlr.CellmataParser
-import org.antlr.v4.runtime.tree.ParseTree
+import org.antlr.v4.runtime.ParserRuleContext
 
 /**
  * This is a debugging string.
@@ -9,9 +9,13 @@ import org.antlr.v4.runtime.tree.ParseTree
  */
 const val MAGIC_UNDEFINED_STRING = "<<THIS IS A MAGIC STRING, UNDEFINED>>"
 
-sealed class AST
+sealed class AST(open val ctx: ParserRuleContext)
 
-data class RootNode(val world: WorldNode, val body: List<Decl>) : AST()
+data class RootNode constructor(
+    override val ctx: ParserRuleContext,
+    val world: WorldNode,
+    val body: List<Decl>
+) : AST(ctx)
 
 /*
  * World definition
@@ -25,148 +29,148 @@ enum class WorldType {
 data class WorldDimension(val size: Int = -1, val type: WorldType = WorldType.UNDEFINED)
 
 data class WorldNode(
-    val ctx: ParseTree,
+    override val ctx: CellmataParser.World_dclContext,
     val dimensions: List<WorldDimension> = emptyList(),
     val tickrate: Int? = null,
     val cellSize: Int? = null
-) : AST()
+) : AST(ctx)
 
 /*
  * Expressions
  */
-abstract class Expr(var type: Type = UncheckedType) : AST()
+abstract class Expr(override val ctx: ParserRuleContext, var type: Type = UncheckedType) : AST(ctx)
 
-data class OrExpr(val ctx: CellmataParser.OrExprContext, val left: Expr, val right: Expr) : Expr()
+data class OrExpr(override val ctx: CellmataParser.OrExprContext, val left: Expr, val right: Expr) : Expr(ctx)
 
-data class AndExpr(val ctx: CellmataParser.AndExprContext, val left: Expr, val right: Expr) : Expr()
+data class AndExpr(override val ctx: CellmataParser.AndExprContext, val left: Expr, val right: Expr) : Expr(ctx)
 
-data class InequalityExpr(val ctx: CellmataParser.NotEqExprContext, val left: Expr, val right: Expr) : Expr()
+data class InequalityExpr(override val ctx: CellmataParser.NotEqExprContext, val left: Expr, val right: Expr) : Expr(ctx)
 
-data class EqualityExpr(val ctx: CellmataParser.EqExprContext, val left: Expr, val right: Expr) : Expr()
+data class EqualityExpr(override val ctx: CellmataParser.EqExprContext, val left: Expr, val right: Expr) : Expr(ctx)
 
-data class MoreThanExpr(val ctx: CellmataParser.MoreExprContext, val left: Expr, val right: Expr) : Expr()
+data class MoreThanExpr(override val ctx: CellmataParser.MoreExprContext, val left: Expr, val right: Expr) : Expr(ctx)
 
-data class MoreEqExpr(val ctx: CellmataParser.MoreEqExprContext, val left: Expr, val right: Expr) : Expr()
+data class MoreEqExpr(override val ctx: CellmataParser.MoreEqExprContext, val left: Expr, val right: Expr) : Expr(ctx)
 
-data class LessThanExpr(val ctx: CellmataParser.LessExprContext, val left: Expr, val right: Expr) : Expr()
+data class LessThanExpr(override val ctx: CellmataParser.LessExprContext, val left: Expr, val right: Expr) : Expr(ctx)
 
-data class LessEqExpr(val ctx: CellmataParser.LessEqExprContext, val left: Expr, val right: Expr) : Expr()
+data class LessEqExpr(override val ctx: CellmataParser.LessEqExprContext, val left: Expr, val right: Expr) : Expr(ctx)
 
-data class AdditionExpr(val ctx: CellmataParser.AdditionExprContext, val left: Expr, val right: Expr) : Expr()
+data class AdditionExpr(override val ctx: CellmataParser.AdditionExprContext, val left: Expr, val right: Expr) : Expr(ctx)
 
-data class SubtractionExpr(val ctx: CellmataParser.SubstractionExprContext, val left: Expr, val right: Expr) : Expr()
+data class SubtractionExpr(override val ctx: CellmataParser.SubstractionExprContext, val left: Expr, val right: Expr) : Expr(ctx)
 
-data class MultiplicationExpr(val ctx: CellmataParser.MultiplictionExprContext, val left: Expr, val right: Expr) : Expr()
+data class MultiplicationExpr(override val ctx: CellmataParser.MultiplictionExprContext, val left: Expr, val right: Expr) : Expr(ctx)
 
-data class DivisionExpr(val ctx: CellmataParser.DivisionExprContext, val left: Expr, val right: Expr) : Expr()
+data class DivisionExpr(override val ctx: CellmataParser.DivisionExprContext, val left: Expr, val right: Expr) : Expr(ctx)
 
-data class PreIncExpr(val ctx: CellmataParser.PreIncExprContext, val value: Expr) : Expr()
+data class PreIncExpr(override val ctx: CellmataParser.PreIncExprContext, val value: Expr) : Expr(ctx)
 
-data class PreDecExpr(val ctx: CellmataParser.PreDecExprContext, val value: Expr) : Expr()
+data class PreDecExpr(override val ctx: CellmataParser.PreDecExprContext, val value: Expr) : Expr(ctx)
 
-data class PostIncExpr(val ctx: CellmataParser.PostIncExprContext, val value: Expr) : Expr()
+data class PostIncExpr(override val ctx: CellmataParser.PostIncExprContext, val value: Expr) : Expr(ctx)
 
-data class PostDecExpr(val ctx: CellmataParser.PostDecExprContext, val value: Expr) : Expr()
+data class PostDecExpr(override val ctx: CellmataParser.PostDecExprContext, val value: Expr) : Expr(ctx)
 
-data class PositiveExpr(val ctx: CellmataParser.PositiveExprContext, val value: Expr) : Expr()
+data class PositiveExpr(override val ctx: CellmataParser.PositiveExprContext, val value: Expr) : Expr(ctx)
 
-data class NegativeExpr(val ctx: CellmataParser.NegativeExprContext, val value: Expr) : Expr()
+data class NegativeExpr(override val ctx: CellmataParser.NegativeExprContext, val value: Expr) : Expr(ctx)
 
-data class InverseExpr(val ctx: CellmataParser.InverseExprContext, val value: Expr) : Expr()
+data class InverseExpr(override val ctx: CellmataParser.InverseExprContext, val value: Expr) : Expr(ctx)
 
-data class ArrayLookupExpr(val ctx: CellmataParser.ArrayLookupExprContext, val ident: String = MAGIC_UNDEFINED_STRING, val index: Expr) : Expr()
+data class ArrayLookupExpr(override val ctx: CellmataParser.ArrayLookupExprContext, val ident: String = MAGIC_UNDEFINED_STRING, val index: Expr) : Expr(ctx)
 
-data class ArrayBodyExpr(val ctx: CellmataParser.ArrayValueExprContext, val values: List<Expr>) : Expr()
+data class ArrayBodyExpr(override val ctx: CellmataParser.ArrayValueExprContext, val values: List<Expr>) : Expr(ctx)
 
-data class ParenExpr(val ctx: CellmataParser.ParenExprContext, val expr: Expr) : Expr()
+data class ParenExpr(override val ctx: CellmataParser.ParenExprContext, val expr: Expr) : Expr(ctx)
 
-data class NamedExpr(val ctx: ParseTree, var ident: String = MAGIC_UNDEFINED_STRING) : Expr()
+data class NamedExpr(override val ctx: ParserRuleContext, var ident: String = MAGIC_UNDEFINED_STRING) : Expr(ctx)
 
-data class ModuloExpr(val ctx: CellmataParser.ModuloExprContext, val left: Expr, val right: Expr) : Expr()
+data class ModuloExpr(override val ctx: CellmataParser.ModuloExprContext, val left: Expr, val right: Expr) : Expr(ctx)
 
-data class FuncExpr(val ctx: CellmataParser.FuncExprContext, val args: List<Expr>, var ident: String = MAGIC_UNDEFINED_STRING) : Expr()
+data class FuncExpr(override val ctx: CellmataParser.FuncExprContext, val args: List<Expr>, var ident: String = MAGIC_UNDEFINED_STRING) : Expr(ctx)
 
-data class StateIndexExpr(val ctx: CellmataParser.StateIndexExprContext) : Expr()
+data class StateIndexExpr(override val ctx: CellmataParser.StateIndexExprContext) : Expr(ctx)
 
 // Literals
-data class IntLiteral(val ctx: CellmataParser.Integer_literalContext, var value: Int = -1) : Expr()
+data class IntLiteral(override val ctx: CellmataParser.Integer_literalContext, var value: Int = -1) : Expr(ctx)
 
-data class BoolLiteral(val ctx: CellmataParser.Bool_literalContext, var value: Boolean = false) : Expr()
+data class BoolLiteral(override val ctx: CellmataParser.Bool_literalContext, var value: Boolean = false) : Expr(ctx)
 
-data class FloatLiteral(val ctx: CellmataParser.Float_literalContext, var value: Float = 0.0F): Expr()
+data class FloatLiteral(override val ctx: CellmataParser.Float_literalContext, var value: Float = 0.0F): Expr(ctx)
 
 // Type conversion
-data class IntToFloatConversion(val expr: Expr) : Expr()
+data class IntToFloatConversion(override val ctx: ParserRuleContext, val expr: Expr) : Expr(ctx)
 
-data class StateArrayToActualNeighbourhoodConversion(val expr: Expr) : Expr()
+data class StateArrayToActualNeighbourhoodConversion(override val ctx: ParserRuleContext, val expr: Expr) : Expr(ctx)
 
 /*
  * Declarations
  */
-sealed class Decl : AST() // state, const, func
+sealed class Decl(override val ctx: ParserRuleContext) : AST(ctx) // state, const, func
 
-data class ConstDecl(val ctx: CellmataParser.Const_declContext, var ident: String = MAGIC_UNDEFINED_STRING, val expr: Expr) : Decl()
+data class ConstDecl(override val ctx: CellmataParser.Const_declContext, var ident: String = MAGIC_UNDEFINED_STRING, val expr: Expr) : Decl(ctx)
 
 data class StateDecl(
-    val ctx: CellmataParser.State_declContext,
+    override val ctx: CellmataParser.State_declContext,
     var ident: String = MAGIC_UNDEFINED_STRING,
     var red: Short = -1,
     var blue: Short = -1,
     var green: Short = -1,
     val body: List<Stmt>
-) : Decl()
+) : Decl(ctx)
 
-data class Coordinate(val ctx: ParseTree, val axes: List<Int> = emptyList())
+data class Coordinate(override val ctx: ParserRuleContext, val axes: List<Int> = emptyList()) : AST(ctx)
 
 data class NeighbourhoodDecl(
-    val ctx: CellmataParser.Neighbourhood_declContext,
+    override val ctx: CellmataParser.Neighbourhood_declContext,
     var ident: String = MAGIC_UNDEFINED_STRING,
     var coords: List<Coordinate> = emptyList()
-) : Decl()
+) : Decl(ctx)
 
-data class FunctionArgs(val ident: String, val type: String): AST()
+data class FunctionArgs(override val ctx: ParserRuleContext, val ident: String, val type: String): AST(ctx)
 
 data class FuncDecl(
-    val ctx: CellmataParser.Func_declContext,
+    override val ctx: CellmataParser.Func_declContext,
     var ident: String = MAGIC_UNDEFINED_STRING,
     var args: List<FunctionArgs> = emptyList(),
     val body: List<Stmt> = emptyList(),
     var returnType: String = MAGIC_UNDEFINED_STRING
-) : Decl()
+) : Decl(ctx)
 
 /*
  * Statements
  */
-sealed class Stmt : AST()
+sealed class Stmt(override val ctx: ParserRuleContext) : AST(ctx)
 
-data class AssignStmt(val ctx: CellmataParser.AssignmentContext, var ident: String = MAGIC_UNDEFINED_STRING, val expr: Expr) : Stmt()
+data class AssignStmt(override val ctx: CellmataParser.AssignmentContext, var ident: String = MAGIC_UNDEFINED_STRING, val expr: Expr) : Stmt(ctx)
 
-data class ConditionalBlock(val ctx: ParseTree, val expr: Expr, val block: List<Stmt>)
+data class ConditionalBlock(override val ctx: ParserRuleContext, val expr: Expr, val block: List<Stmt>) : AST(ctx)
 
-data class IfStmt(val ctx: CellmataParser.If_stmtContext, val conditionals: List<ConditionalBlock>, val elseBlock: List<Stmt>?) : Stmt()
+data class IfStmt(override val ctx: CellmataParser.If_stmtContext, val conditionals: List<ConditionalBlock>, val elseBlock: List<Stmt>?) : Stmt(ctx)
 
-data class ForStmt(val ctx: CellmataParser.For_stmtContext, val initPart: AssignStmt, val condition: Expr, val postIterationPart: AssignStmt) : Stmt()
+data class ForStmt(override val ctx: CellmataParser.For_stmtContext, val initPart: AssignStmt, val condition: Expr, val postIterationPart: AssignStmt) : Stmt(ctx)
 
-data class BreakStmt(val ctx: CellmataParser.Break_stmtContext) : Stmt()
+data class BreakStmt(override val ctx: CellmataParser.Break_stmtContext) : Stmt(ctx)
 
-data class ContinueStmt(val ctx: CellmataParser.Continue_stmtContext) : Stmt()
+data class ContinueStmt(override val ctx: CellmataParser.Continue_stmtContext) : Stmt(ctx)
 
-data class BecomeStmt(val ctx: CellmataParser.Become_stmtContext, val state: Expr) : Stmt()
+data class BecomeStmt(override val ctx: CellmataParser.Become_stmtContext, val state: Expr) : Stmt(ctx)
 
-data class PreIncStmt(val ctx: CellmataParser.PreIncStmtContext, val variable: Expr) : Stmt()
+data class PreIncStmt(override val ctx: CellmataParser.PreIncStmtContext, val variable: Expr) : Stmt(ctx)
 
-data class PostIncStmt(val ctx: CellmataParser.PostIncStmtContext, val variable:  Expr) : Stmt()
+data class PostIncStmt(override val ctx: CellmataParser.PostIncStmtContext, val variable:  Expr) : Stmt(ctx)
 
-data class PreDecStmt(val ctx: CellmataParser.PreDecStmtContext, val variable: Expr) : Stmt()
+data class PreDecStmt(override val ctx: CellmataParser.PreDecStmtContext, val variable: Expr) : Stmt(ctx)
 
-data class PostDecStmt(val ctx: CellmataParser.PostDecStmtContext, val variable: Expr) : Stmt()
+data class PostDecStmt(override val ctx: CellmataParser.PostDecStmtContext, val variable: Expr) : Stmt(ctx)
 
-data class ReturnStmt(val ctx: CellmataParser.Return_stmtContext, val value: Expr) : Stmt()
+data class ReturnStmt(override val ctx: CellmataParser.Return_stmtContext, val value: Expr) : Stmt(ctx)
 
 /*
  * Error nodes are used when something goes wrong in mapper.kt and is returned by the failing function.
  */
-object ErrorAST : AST()
-object ErrorDecl : Decl()
-object ErrorStmt : Stmt()
-object ErrorExpr : Expr()
+class ErrorAST(override val ctx: ParserRuleContext) : AST(ctx)
+class ErrorDecl(override val ctx: ParserRuleContext) : Decl(ctx)
+class ErrorStmt(override val ctx: ParserRuleContext) : Stmt(ctx)
+class ErrorExpr(override val ctx: ParserRuleContext) : Expr(ctx)

--- a/compiler/src/main/kotlin/ast/ast.kt
+++ b/compiler/src/main/kotlin/ast/ast.kt
@@ -157,3 +157,11 @@ data class PreDecStmt(val ctx: CellmataParser.PreDecStmtContext, val variable: E
 data class PostDecStmt(val ctx: CellmataParser.PostDecStmtContext, val variable: Expr) : Stmt()
 
 data class ReturnStmt(val ctx: CellmataParser.Return_stmtContext, val value: Expr) : Stmt()
+
+/*
+ * Error nodes are used when something goes wrong in mapper.kt and is returned by the failing function.
+ */
+object ErrorAST : AST()
+object ErrorDecl : Decl()
+object ErrorStmt : Stmt()
+object ErrorExpr : Expr()

--- a/compiler/src/main/kotlin/ast/types.kt
+++ b/compiler/src/main/kotlin/ast/types.kt
@@ -20,16 +20,3 @@ fun typeFromString(str: String) {
         else -> error("Type not recognised.") // TODO Replace with smarter error reporting
     }
 }
-
-fun wrapInImplicitConversion(expr: Expr, targetType: Type) : Expr {
-    // There are two types of implicit type conversions:
-    // int -> float
-    // array<state> -> actual neighbourhood
-
-    val type = expr.type
-    return when {
-        type is IntegerType && targetType is FloatType -> IntToFloatConversion(expr)
-        type is ArrayType && type.subtype is StateType && targetType is ActualNeighbourhoodType -> StateArrayToActualNeighbourhoodConversion(expr)
-        else -> error("Cannot implicitly convert $type to $targetType.") // TODO Replace with smarter error reporting
-    }
-}

--- a/compiler/src/main/kotlin/errorhandling.kt
+++ b/compiler/src/main/kotlin/errorhandling.kt
@@ -28,7 +28,7 @@ abstract class CompileError(msg: String) : java.lang.RuntimeException(msg) {
 /**
  * An compiler error based on the context from the antlr parser.
  */
-class ErrorFromContext(private val ctx: ParserRuleContext, private val description: String) : CompileError(description) {
+open class ErrorFromContext(private val ctx: ParserRuleContext, private val description: String) : CompileError(description) {
 
     override fun description(): String {
         return description

--- a/compiler/src/main/kotlin/errorhandling.kt
+++ b/compiler/src/main/kotlin/errorhandling.kt
@@ -13,7 +13,7 @@ interface CompileError {
     /**
      * The description of the error in plain text
      */
-    fun message(): String
+    fun description(): String
 
     /**
      * The line number on which the first character that produced this error, line=1..n
@@ -30,10 +30,10 @@ interface CompileError {
 /**
  * An compiler error based on the context from the antlr parser.
  */
-class ErrorFromContext(private val ctx: ParserRuleContext, private val message: String) : CompileError {
+class ErrorFromContext(private val ctx: ParserRuleContext, private val description: String) : CompileError {
 
-    override fun message(): String {
-        return message
+    override fun description(): String {
+        return description
     }
 
     override fun getLine(): Int {
@@ -57,6 +57,9 @@ object ErrorLogger {
         errors += err
     }
 
+    /**
+     * Assert that there is no errors. Throws a TerminatedCompilationException if there is any errors.
+     */
     fun assertNoErrors() {
         if (hasErrors()) {
             throw TerminatedCompilationException("Errors occurred.")
@@ -67,15 +70,31 @@ object ErrorLogger {
         return errors.size > 0
     }
 
+    /**
+     * Prints all errors in a nicely formatted way.
+     */
     fun printAllErrors() {
         for (e in errors) {
-            println("Error at (${e.getLine()}, ${e.getCharPositionInLine()}): ${e.message()}")
+            println("Error at (${e.getLine()}, ${e.getCharPositionInLine()}): ${e.description()}")
         }
+    }
+
+    /**
+     * Returns a string consisting of a number of spaces followed by a ^. This string is used to point to the exact
+     * position of the error in error messages. E.g. "      ^"
+     */
+    private fun errorPointerString(charPosition: Int): String {
+        val pointerStringBuilder = StringBuilder()
+        repeat(charPosition) {
+            pointerStringBuilder.append(" ")
+        }
+        pointerStringBuilder.append("^")
+        return pointerStringBuilder.toString()
     }
 }
 
 /**
- * When a critical error occurs, since error is thrown to terminate the compilation immediately. This differs from
- * ErrorLogger and it's CompileErrors since multiple of these can occur before the compilation terminates.
+ * When a critical error occurs, this error is thrown to terminate the compilation immediately. This differs from
+ * the ErrorLogger and CompileErrors since multiple of these can occur before the compilation terminates.
  */
 class TerminatedCompilationException(msg: String) : RuntimeException(msg)

--- a/compiler/src/main/kotlin/errorhandling.kt
+++ b/compiler/src/main/kotlin/errorhandling.kt
@@ -6,29 +6,29 @@ import org.antlr.v4.runtime.ParserRuleContext
  * Interface for all compiler errors that does not terminate a compiler phase.
  * @see ErrorLogger
  */
-interface CompileError {
+abstract class CompileError(msg: String) : java.lang.RuntimeException(msg) {
 
     /**
      * The description of the error in plain text
      */
-    fun description(): String
+    abstract fun description(): String
 
     /**
      * The line number on which the first character that produced this error, line=1..n
      */
-    fun getLine(): Int
+    abstract fun getLine(): Int
 
     /**
      * The index of the first character of this error relative to the
      * beginning of the line at which it occurs, 0..n-1
      */
-    fun getCharPositionInLine(): Int
+    abstract fun getCharPositionInLine(): Int
 }
 
 /**
  * An compiler error based on the context from the antlr parser.
  */
-class ErrorFromContext(private val ctx: ParserRuleContext, private val description: String) : CompileError {
+class ErrorFromContext(private val ctx: ParserRuleContext, private val description: String) : CompileError(description) {
 
     override fun description(): String {
         return description

--- a/compiler/src/main/kotlin/errorhandling.kt
+++ b/compiler/src/main/kotlin/errorhandling.kt
@@ -1,8 +1,6 @@
 package dk.aau.cs.d409f19.cellumata
 
 import org.antlr.v4.runtime.ParserRuleContext
-import java.nio.file.Files
-import java.nio.file.Path
 
 /**
  * Interface for all compiler errors that does not terminate a compiler phase.
@@ -43,7 +41,6 @@ class ErrorFromContext(private val ctx: ParserRuleContext, private val descripti
     override fun getCharPositionInLine(): Int {
         return ctx.start.charPositionInLine
     }
-
 }
 
 /**
@@ -77,6 +74,10 @@ object ErrorLogger {
         for (e in errors) {
             println("Error at (${e.getLine()}, ${e.getCharPositionInLine()}): ${e.description()}")
         }
+    }
+
+    fun allErrors(): List<CompileError> {
+        return errors
     }
 
     /**

--- a/compiler/src/main/kotlin/errorhandling.kt
+++ b/compiler/src/main/kotlin/errorhandling.kt
@@ -72,7 +72,7 @@ object ErrorLogger {
      */
     fun printAllErrors() {
         for (e in errors) {
-            println("Error at (${e.getLine()}, ${e.getCharPositionInLine()}): ${e.description()}")
+            System.err.println("Error at (${e.getLine()}, ${e.getCharPositionInLine()}): ${e.description()}")
         }
     }
 

--- a/compiler/src/main/kotlin/errorhandling.kt
+++ b/compiler/src/main/kotlin/errorhandling.kt
@@ -1,0 +1,67 @@
+package dk.aau.cs.d409f19.cellumata
+
+import org.antlr.v4.runtime.ParserRuleContext
+
+/**
+ * Interface for all compiler errors that does not terminate a compiler phase.
+ * @see ErrorLogger
+ */
+interface CompileError {
+
+    /**
+     * The description of the error in plain text
+     */
+    fun message(): String
+
+    /**
+     * The line number on which the first character that produced this error, line=1..n
+     */
+    fun getLine(): Int
+
+    /**
+     * The index of the first character of this error relative to the
+     * beginning of the line at which it occurs, 0..n-1
+     */
+    fun getCharPositionInLine(): Int
+}
+
+/**
+ * An compiler error based on the context from the antlr parser.
+ */
+class ErrorFromContext(private val ctx: ParserRuleContext, private val message: String) : CompileError {
+
+    override fun message(): String {
+        return message
+    }
+
+    override fun getLine(): Int {
+        return ctx.start.line
+    }
+
+    override fun getCharPositionInLine(): Int {
+        return ctx.start.charPositionInLine
+    }
+
+}
+
+/**
+ * The ErrorLogger holds all compile errors so far.
+ */
+object ErrorLogger {
+
+    private val errors: MutableList<CompileError> = mutableListOf()
+
+    fun add(err: CompileError) {
+        errors += err
+    }
+
+    fun hasErrors(): Boolean {
+        return errors.size > 0
+    }
+
+    fun printAllErrors() {
+        for (e in errors) {
+            println("Error (${e.getLine()}, ${e.getCharPositionInLine()}): ${e.message()}")
+        }
+    }
+}

--- a/compiler/src/main/kotlin/errorhandling.kt
+++ b/compiler/src/main/kotlin/errorhandling.kt
@@ -1,6 +1,8 @@
 package dk.aau.cs.d409f19.cellumata
 
 import org.antlr.v4.runtime.ParserRuleContext
+import java.nio.file.Files
+import java.nio.file.Path
 
 /**
  * Interface for all compiler errors that does not terminate a compiler phase.
@@ -51,8 +53,14 @@ object ErrorLogger {
 
     private val errors: MutableList<CompileError> = mutableListOf()
 
-    fun add(err: CompileError) {
+    fun registerError(err: CompileError) {
         errors += err
+    }
+
+    fun assertNoErrors() {
+        if (hasErrors()) {
+            throw TerminatedCompilationException("Errors occurred.")
+        }
     }
 
     fun hasErrors(): Boolean {
@@ -61,7 +69,13 @@ object ErrorLogger {
 
     fun printAllErrors() {
         for (e in errors) {
-            println("Error (${e.getLine()}, ${e.getCharPositionInLine()}): ${e.message()}")
+            println("Error at (${e.getLine()}, ${e.getCharPositionInLine()}): ${e.message()}")
         }
     }
 }
+
+/**
+ * When a critical error occurs, since error is thrown to terminate the compilation immediately. This differs from
+ * ErrorLogger and it's CompileErrors since multiple of these can occur before the compilation terminates.
+ */
+class TerminatedCompilationException(msg: String) : RuntimeException(msg)

--- a/compiler/src/main/kotlin/main.kt
+++ b/compiler/src/main/kotlin/main.kt
@@ -1,20 +1,17 @@
 package dk.aau.cs.d409f19.cellumata
 
-import dk.aau.cs.d409f19.antlr.*
-import dk.aau.cs.d409f19.cellumata.ast.reduce
+import dk.aau.cs.d409f19.antlr.CellmataLexer
+import dk.aau.cs.d409f19.antlr.CellmataParser
 import dk.aau.cs.d409f19.cellumata.ast.SymbolTable
-import org.antlr.v4.runtime.CharStreams
+import dk.aau.cs.d409f19.cellumata.ast.reduce
 import dk.aau.cs.d409f19.cellumata.walkers.LiteralExtractorVisitor
 import dk.aau.cs.d409f19.cellumata.walkers.ScopeCheckVisitor
-import jdk.nashorn.internal.objects.NativeArray.reduce
+import org.antlr.v4.runtime.CharStreams
 import org.antlr.v4.runtime.CommonTokenStream
-import java.lang.Exception
+import java.nio.file.Path
 import java.nio.file.Paths
 
-fun main() {
-
-    val path = Paths.get("src/main/resources/stress.cell")
-
+fun compile(path: Path) {
     try {
         val inputStream = CharStreams.fromPath(path)
         val lexer = CellmataLexer(inputStream)
@@ -50,4 +47,9 @@ fun main() {
         println("Critical error occurred. Maybe something is wrong in the compiler. Emptying ErrorLogger:")
         ErrorLogger.printAllErrors()
     }
+}
+
+fun main() {
+    val path = Paths.get("src/main/resources/stress.cell")
+    compile(path)
 }

--- a/compiler/src/main/kotlin/main.kt
+++ b/compiler/src/main/kotlin/main.kt
@@ -2,19 +2,34 @@ package dk.aau.cs.d409f19.cellumata
 
 import dk.aau.cs.d409f19.antlr.*
 import dk.aau.cs.d409f19.cellumata.ast.visit
-import org.antlr.v4.runtime.ANTLRFileStream
+import org.antlr.v4.runtime.CharStreams
 import org.antlr.v4.runtime.CommonTokenStream
+import java.lang.Exception
+import java.nio.file.Paths
 
 fun main() {
-    val inputStream = ANTLRFileStream("src/main/resources/stress.cell")
-    val lexer = CellmataLexer(inputStream)
-    val tokenStream = CommonTokenStream(lexer)
-    val parser = CellmataParser(tokenStream)
 
-    val startContext = parser.start()
+    val path = Paths.get("src/main/resources/stress.cell")
 
-    val ast = visit(startContext)
+    try {
+        val inputStream = CharStreams.fromPath(path)
+        val lexer = CellmataLexer(inputStream)
+        val tokenStream = CommonTokenStream(lexer)
+        val parser = CellmataParser(tokenStream)
 
-    println(ast)
+        // Build AST
+        val startContext = parser.start()
+        val ast = visit(startContext)
+        ErrorLogger.assertNoErrors()
 
+        println(ast)
+
+    } catch (e:  TerminatedCompilationException) {
+
+        println("Compilation failed: ${e.message}")
+        ErrorLogger.printAllErrors()
+
+    } catch (e: Exception) {
+        e.printStackTrace()
+    }
 }

--- a/compiler/src/main/kotlin/main.kt
+++ b/compiler/src/main/kotlin/main.kt
@@ -27,6 +27,7 @@ fun main() {
     } catch (e:  TerminatedCompilationException) {
 
         println("Compilation failed: ${e.message}")
+        ErrorLogger.printAllErrors()
 
     } catch (e: Exception) {
         e.printStackTrace()

--- a/compiler/src/main/kotlin/main.kt
+++ b/compiler/src/main/kotlin/main.kt
@@ -27,7 +27,6 @@ fun main() {
     } catch (e:  TerminatedCompilationException) {
 
         println("Compilation failed: ${e.message}")
-        ErrorLogger.printAllErrors()
 
     } catch (e: Exception) {
         e.printStackTrace()

--- a/compiler/src/main/kotlin/main.kt
+++ b/compiler/src/main/kotlin/main.kt
@@ -36,7 +36,7 @@ fun compile(path: Path) {
     } catch (e:  TerminatedCompilationException) {
 
         // Compilated failed due to errors in cell code
-        println("Compilation failed: ${e.message}")
+        System.err.println("Compilation failed: ${e.message}")
         ErrorLogger.printAllErrors()
 
     } catch (e: Exception) {
@@ -44,7 +44,7 @@ fun compile(path: Path) {
         // Critical error happened, maybe something is be wrong in the compiler
         // Printing stack trace and errors for debugging reasons
         e.printStackTrace()
-        println("Critical error occurred. Maybe something is wrong in the compiler. Emptying ErrorLogger:")
+        System.err.println("Critical error occurred. Maybe something is wrong in the compiler. Emptying ErrorLogger:")
         ErrorLogger.printAllErrors()
     }
 }

--- a/compiler/src/main/kotlin/main.kt
+++ b/compiler/src/main/kotlin/main.kt
@@ -11,6 +11,8 @@ import org.antlr.v4.runtime.CommonTokenStream
 import java.nio.file.Path
 import java.nio.file.Paths
 
+val path = Paths.get("src/main/resources/stress.cell")
+
 fun compile(path: Path) {
     try {
         val inputStream = CharStreams.fromPath(path)
@@ -21,10 +23,10 @@ fun compile(path: Path) {
         // Build AST
         val startContext = parser.start()
         val ast = reduce(startContext)
-        println(ast)
+        // Asserts that no errors has been found during the last phase
         ErrorLogger.assertNoErrors()
 
-        // Literals
+        // Extract literals
         LiteralExtractorVisitor().visit(ast)
 
         // Symbol table and scope
@@ -33,9 +35,9 @@ fun compile(path: Path) {
         println(symbolTable)
         ErrorLogger.assertNoErrors()
 
-    } catch (e:  TerminatedCompilationException) {
+    } catch (e: TerminatedCompilationException) {
 
-        // Compilated failed due to errors in cell code
+        // Compilation failed due to errors in program code
         System.err.println("Compilation failed: ${e.message}")
         ErrorLogger.printAllErrors(path)
 
@@ -50,6 +52,5 @@ fun compile(path: Path) {
 }
 
 fun main() {
-    val path = Paths.get("src/main/resources/stress.cell")
     compile(path)
 }

--- a/compiler/src/main/kotlin/main.kt
+++ b/compiler/src/main/kotlin/main.kt
@@ -37,10 +37,16 @@ fun main() {
 
     } catch (e:  TerminatedCompilationException) {
 
+        // Compilated failed due to errors in cell code
         println("Compilation failed: ${e.message}")
         ErrorLogger.printAllErrors()
 
     } catch (e: Exception) {
+
+        // Critical error happened, maybe something is be wrong in the compiler
+        // Printing stack trace and errors for debugging reasons
         e.printStackTrace()
+        println("Critical error occurred. Maybe something is wrong in the compiler. Emptying ErrorLogger:")
+        ErrorLogger.printAllErrors()
     }
 }

--- a/compiler/src/main/kotlin/main.kt
+++ b/compiler/src/main/kotlin/main.kt
@@ -37,7 +37,7 @@ fun compile(path: Path) {
 
         // Compilated failed due to errors in cell code
         System.err.println("Compilation failed: ${e.message}")
-        ErrorLogger.printAllErrors()
+        ErrorLogger.printAllErrors(path)
 
     } catch (e: Exception) {
 
@@ -45,7 +45,7 @@ fun compile(path: Path) {
         // Printing stack trace and errors for debugging reasons
         e.printStackTrace()
         System.err.println("Critical error occurred. Maybe something is wrong in the compiler. Emptying ErrorLogger:")
-        ErrorLogger.printAllErrors()
+        ErrorLogger.printAllErrors(path)
     }
 }
 

--- a/compiler/src/main/kotlin/walkers/symbol.kt
+++ b/compiler/src/main/kotlin/walkers/symbol.kt
@@ -6,7 +6,7 @@ import dk.aau.cs.d409f19.cellumata.ast.*
 import org.antlr.v4.runtime.ParserRuleContext
 import java.lang.Exception
 
-class UndeclaredNameException(val ctx: ParserRuleContext, val ident: String) : ErrorFromContext(ctx, "\"$ident\" is undeclared.")
+class UndeclaredNameException(ctx: ParserRuleContext, val ident: String) : ErrorFromContext(ctx, "\"$ident\" is undeclared.")
 
 class ScopeCheckVisitor(val symbolTable: SymbolTable) : BaseASTVisitor() {
     override fun visit(node: RootNode) {

--- a/compiler/src/main/kotlin/walkers/symbol.kt
+++ b/compiler/src/main/kotlin/walkers/symbol.kt
@@ -1,9 +1,12 @@
 package dk.aau.cs.d409f19.cellumata.walkers
 
+import dk.aau.cs.d409f19.cellumata.ErrorFromContext
+import dk.aau.cs.d409f19.cellumata.ErrorLogger
 import dk.aau.cs.d409f19.cellumata.ast.*
+import org.antlr.v4.runtime.ParserRuleContext
 import java.lang.Exception
 
-class SymbolException(val ident: String) : Exception("\"$ident\" was used before it was declared")
+class SymbolUndeclaredException(val ctx: ParserRuleContext, val ident: String) : ErrorFromContext(ctx, "\"$ident\" was used before it was declared")
 
 class ScopeCheckVisitor(val symbolTable: SymbolTable) : BaseASTVisitor() {
     override fun visit(node: RootNode) {
@@ -21,7 +24,7 @@ class ScopeCheckVisitor(val symbolTable: SymbolTable) : BaseASTVisitor() {
 
     override fun visit(node: NamedExpr) {
         if (symbolTable.getSymbol(node.ident) == null) {
-            throw SymbolException(node.ident)
+            ErrorLogger.registerError(SymbolUndeclaredException(node.ctx, node.ident))
         }
         super.visit(node)
     }
@@ -61,7 +64,7 @@ class ScopeCheckVisitor(val symbolTable: SymbolTable) : BaseASTVisitor() {
 
     override fun visit(node: FuncExpr) {
         if (symbolTable.getSymbol(node.ident) == null) {
-            throw SymbolException(node.ident)
+            ErrorLogger.registerError(SymbolUndeclaredException(node.ctx, node.ident))
         }
         super.visit(node)
     }

--- a/compiler/src/main/kotlin/walkers/value.kt
+++ b/compiler/src/main/kotlin/walkers/value.kt
@@ -83,7 +83,7 @@ class LiteralExtractorVisitor : BaseASTVisitor() {
     override fun visit(node: FuncDecl) {
         super.visit(node)
 
-        node.args = node.ctx.func_decl_arg().map { FunctionArgs(it.IDENT().text, it.type_ident().text) }.toList()
+        node.args = node.ctx.func_decl_arg().map { FunctionArgs(it, it.IDENT().text, it.type_ident().text) }.toList()
 
         node.ident = node.ctx.func_ident().text
         node.returnType = node.ctx.type_ident().text

--- a/compiler/src/main/kotlin/walkers/visitor.kt
+++ b/compiler/src/main/kotlin/walkers/visitor.kt
@@ -13,6 +13,8 @@ interface ASTVisitor {
 
     fun visit(node: NeighbourhoodDecl)
 
+    fun visit(node: Coordinate)
+
     fun visit(node: FuncDecl)
 
     fun visit(node: Expr)
@@ -128,6 +130,10 @@ abstract class BaseASTVisitor: ASTVisitor {
     }
 
     override fun visit(node: NeighbourhoodDecl) {
+        node.coords.forEach { visit(it) }
+    }
+
+    override fun visit(node: Coordinate) {
         // no-op
     }
 
@@ -322,6 +328,7 @@ abstract class BaseASTVisitor: ASTVisitor {
     }
 
     override fun visit(node: ConditionalBlock) {
+        visit(node.expr)
         node.block.forEach { stmt -> visit(stmt) }
     }
 

--- a/compiler/src/main/resources/stress.cell
+++ b/compiler/src/main/resources/stress.cell
@@ -23,6 +23,8 @@ state s1 (255, 0, 12) {
     let c = true == false;
     let d = true != false;
     let e = 2 > 3.0;
+    e = abe;
+    dec = abe;
     let f = 2 >= 3.0;
     let g = 2 < 3.0;
     let h = 2 <= 3.0;

--- a/compiler/src/test/kotlin/test.kt
+++ b/compiler/src/test/kotlin/test.kt
@@ -1,23 +1,16 @@
 package dk.aau.cs.d409f19
 
-import dk.aau.cs.d409f19.antlr.CellmataLexer
-import dk.aau.cs.d409f19.antlr.CellmataParser
-import dk.aau.cs.d409f19.cellumata.ast.reduce
-import org.antlr.v4.runtime.ANTLRFileStream
-import org.antlr.v4.runtime.CommonTokenStream
+import dk.aau.cs.d409f19.cellumata.compile
+import dk.aau.cs.d409f19.cellumata.path
 import org.junit.jupiter.api.Test
 
 class CompilerTests {
 
+    /**
+     * Calls compile function in main
+     */
     @Test
     fun `Run compiler`() {
-        val inputStream = ANTLRFileStream("src/main/resources/stress.cell")
-        val lexer = CellmataLexer(inputStream)
-        val tokenStream = CommonTokenStream(lexer)
-        val parser = CellmataParser(tokenStream)
-
-        val startContext = parser.start()
-
-        val ast = reduce(startContext)
+        compile(path)
     }
 }


### PR DESCRIPTION
The ErrorLogger object holds all errors so far.

Small compile errors derive from the CompileError interface (or more likely the ErrorFromContext that uses an ANTLR's parser context). CompileErrors should be registered in the ErrorLogger and compilation should continue. After each phase in the compiler, the ErrorLogger is check for errors and prints any errors accumulated, stopping the compilation.

Major compile errors should use throw the TerminatedCompilationException which will stop the compilation immediately.

Any other exception is considered an error in the compiler, i.e. an error by us and not the programmer of the .cell program.

Resolves #47