### PR TITLE
Implemented type checker

### DIFF
--- a/compiler/src/main/antlr/Cellmata.g4
+++ b/compiler/src/main/antlr/Cellmata.g4
@@ -72,11 +72,11 @@ modifiable_ident : var_ident | array_lookup ;
 var_ident : IDENT ;
 
 // Type declaration
-type_ident : IDENT | type_spec ;
-type_spec
+type_ident
     : array_decl # typeArray
     | TYPE_BOOLEAN # typeBoolean
-    | TYPE_NUMBER # typeNumber
+    | TYPE_INTEGER # typeInteger
+    | TYPE_FLOAT # typeFloat
     | STMT_NEIGHBOUR # typeNeighbour
     | STMT_STATE # typeState
     ;
@@ -197,8 +197,9 @@ STMT_FOR : 'for' ;
 STMT_BREAK : 'break' ;
 STMT_CONTINUE : 'continue' ;
 
-TYPE_NUMBER : 'number' ;
-TYPE_BOOLEAN : 'boolean' | 'bool' ;
+TYPE_INTEGER : 'int' ;
+TYPE_FLOAT : 'float' ;
+TYPE_BOOLEAN : 'bool' ;
 
 LITERAL_TRUE : 'true' ;
 LITERAL_FALSE : 'false' ;

--- a/compiler/src/main/kotlin/ast/reduce.kt
+++ b/compiler/src/main/kotlin/ast/reduce.kt
@@ -119,7 +119,8 @@ private fun reduceExpr(node: ParseTree): Expr {
         is CellmataParser.StateIndexExprContext -> StateIndexExpr(ctx = node)
         is CellmataParser.ArrayValueExprContext -> ArrayBodyExpr(
             ctx = node,
-            values = node.array_value().array_body().expr().map(::reduceExpr)
+            values = node.array_value().array_body().expr().map(::reduceExpr),
+            declaredType = typeFromCtx(node.value.type_ident())
         )
         is CellmataParser.NumberLiteralContext -> reduceExpr(node.value)
         is CellmataParser.BoolLiteralContext -> reduceExpr(node.value)
@@ -138,7 +139,10 @@ private fun reduceExpr(node: ParseTree): Expr {
 private fun reduceStmt(node: ParseTree): Stmt {
     return when (node) {
         is CellmataParser.Assign_stmtContext -> reduceStmt(node.assignment())
-        is CellmataParser.AssignmentContext -> AssignStmt(ctx = node, expr = reduceExpr(node.expr()))
+        is CellmataParser.AssignmentContext -> AssignStmt(
+            ctx = node,
+            expr = reduceExpr(node.expr())
+        )
         is CellmataParser.If_stmtContext -> IfStmt(
             ctx = node,
             conditionals = listOf( // Create list of list of ConditionalBlocks, then flatten to list of ConditionalBlocks
@@ -184,7 +188,10 @@ private fun reduceStmt(node: ParseTree): Stmt {
 
 private fun reduceDecl(node: ParseTree): Decl {
     return when (node) {
-        is CellmataParser.Const_declContext -> ConstDecl(ctx = node, expr = reduceExpr(node.expr()))
+        is CellmataParser.Const_declContext -> ConstDecl(
+            ctx = node,
+            expr = reduceExpr(node.expr())
+        )
         is CellmataParser.State_declContext -> StateDecl(
             ctx = node,
             body = reduceCodeBlock(node.children // Get the body/code block

--- a/compiler/src/main/kotlin/ast/symbol.kt
+++ b/compiler/src/main/kotlin/ast/symbol.kt
@@ -34,6 +34,7 @@ private val RESERVED_SYMBOLS: List<String> = listOf(
     "pow"
 )
 
+@Deprecated("Use CreatingSymbolTableSession")
 class SymbolTable {
     private val root: Table = Table()
     private val scopeStack: Stack<Table> = Stack()
@@ -65,6 +66,18 @@ class SymbolTable {
         return null
     }
 
+    fun getSymbolType(name: String): Type? {
+        val symbol = getSymbol(name) ?: return null
+
+        return when(symbol) {
+            is TypedNode -> symbol.getType()
+            is StateDecl -> StateType
+            is ConstDecl -> symbol.type
+            is FuncDecl -> symbol.returnType
+            else -> null
+        }
+    }
+
     fun createScope() {
         val newScope = Table()
         scopeStack.peek().tables.add(newScope)
@@ -78,5 +91,112 @@ class SymbolTable {
 
     fun openScope(index: Int) {
         scopeStack.push(scopeStack.peek().tables[index])
+    }
+}
+
+class CreatingSymbolTableSession(symbolTable: Table) {
+    private val scopeStack: Stack<Table> = Stack()
+
+    init {
+        scopeStack.push(Table(tables = mutableListOf(symbolTable))) // God scope
+        scopeStack.push(symbolTable)
+    }
+
+    fun openScope() {
+        val newScope = Table()
+        scopeStack.peek().tables.add(newScope)
+        scopeStack.push(newScope)
+    }
+
+    fun closeScope() {
+        assert(scopeStack.size > 1) { "Tried to remove root scope from symbol table" }
+        scopeStack.pop()
+    }
+
+    fun insertSymbol(ident: String, node: AST) {
+        val table = scopeStack.peek()
+
+        if (RESERVED_SYMBOLS.contains(ident)) {
+            throw SymbolRedefinitionException(ident = ident)
+        }
+
+        if (table.symbols.containsKey(ident)) {
+            throw SymbolRedefinitionException(ident = ident)
+        }
+
+        table.symbols[ident] = node
+    }
+
+    fun getSymbol(name: String): AST? {
+        for (table in scopeStack) {
+            if (table.symbols.containsKey(name)) {
+                return table.symbols.get(name)
+            }
+        }
+        return null
+    }
+
+    fun getSymbolType(name: String): Type? {
+        val symbol = getSymbol(name) ?: return null
+
+        return when(symbol) {
+            is TypedNode -> symbol.getType()
+            is StateDecl -> StateType
+            is ConstDecl -> symbol.type
+            is FuncDecl -> symbol.returnType
+            else -> null
+        }
+    }
+
+    fun getRootTable(): Table {
+        // Get global scope from god scope
+        return scopeStack[0].tables[0]
+    }
+}
+
+class ViewingSymbolTableSession(val symbolTable: Table) {
+    private val indexStack: Stack<Int> = Stack()
+    private val scopeStack: Stack<Table> = Stack()
+
+    init {
+        indexStack.push(0)
+        scopeStack.push(Table(tables = mutableListOf(symbolTable))) // God scope
+
+        // Enter global scope
+        indexStack.push(0)
+        scopeStack.push(symbolTable)
+    }
+
+    fun openScope() {
+        val index = indexStack.peek()
+        scopeStack.push(scopeStack.peek().tables[index])
+        indexStack.push(0)
+    }
+
+    fun closeScope() {
+        indexStack.pop()
+        scopeStack.pop()
+        indexStack.push(indexStack.pop() + 1)
+    }
+
+    fun getSymbol(name: String): AST? {
+        for (table in scopeStack) {
+            if (table.symbols.containsKey(name)) {
+                return table.symbols.get(name)
+            }
+        }
+        return null
+    }
+
+    fun getSymbolType(name: String): Type? {
+        val symbol = getSymbol(name) ?: return null
+
+        return when(symbol) {
+            is TypedNode -> symbol.getType()
+            is StateDecl -> StateType
+            is ConstDecl -> symbol.type
+            is FuncDecl -> symbol.returnType
+            else -> null
+        }
     }
 }

--- a/compiler/src/main/kotlin/main.kt
+++ b/compiler/src/main/kotlin/main.kt
@@ -1,10 +1,11 @@
 package dk.aau.cs.d409f19.cellumata
 
-import dk.aau.cs.d409f19.antlr.*
+import dk.aau.cs.d409f19.antlr.CellmataLexer
+import dk.aau.cs.d409f19.antlr.CellmataParser
 import dk.aau.cs.d409f19.cellumata.ast.reduce
-import dk.aau.cs.d409f19.cellumata.ast.SymbolTable
 import dk.aau.cs.d409f19.cellumata.walkers.LiteralExtractorVisitor
 import dk.aau.cs.d409f19.cellumata.walkers.ScopeCheckVisitor
+import dk.aau.cs.d409f19.cellumata.walkers.TypeChecker
 import org.antlr.v4.runtime.ANTLRFileStream
 import org.antlr.v4.runtime.CommonTokenStream
 
@@ -22,7 +23,10 @@ fun main() {
 
     LiteralExtractorVisitor().visit(ast)
 
-    val symbolTable = SymbolTable()
-    ScopeCheckVisitor(symbolTable).visit(ast)
+    val scopeChecker = ScopeCheckVisitor()
+    scopeChecker.visit(ast)
+    val symbolTable = scopeChecker.getSymbolTable()
     println(symbolTable)
+
+    TypeChecker(symbolTable).visit(ast)
 }

--- a/compiler/src/main/kotlin/walkers/type.kt
+++ b/compiler/src/main/kotlin/walkers/type.kt
@@ -1,0 +1,326 @@
+package dk.aau.cs.d409f19.cellumata.walkers
+
+import dk.aau.cs.d409f19.cellumata.ast.*
+import java.lang.Exception
+import kotlin.AssertionError
+
+class TypeError : Exception()
+
+class TypeChecker(symbolTable: Table) : ScopedASTVisitor(symbolTable = symbolTable) {
+    override fun visit(node: OrExpr) {
+        super.visit(node)
+
+        if (node.left.getType() != BooleanType) {
+            throw TypeError()
+        }
+        if (node.right.getType() != BooleanType) {
+            throw TypeError()
+        }
+
+        node.setType(BooleanType)
+    }
+
+    override fun visit(node: AndExpr) {
+        super.visit(node)
+
+        if (node.left.getType() != BooleanType) {
+            throw TypeError()
+        }
+        if (node.right.getType() != BooleanType) {
+            throw TypeError()
+        }
+
+        node.setType(BooleanType)
+    }
+
+    override fun visit(node: InequalityExpr) {
+        super.visit(node)
+
+        node.setType(when {
+            node.left.getType() == BooleanType && node.right.getType() == BooleanType -> BooleanType
+            node.left.getType() == IntegerType && node.right.getType() == IntegerType -> BooleanType
+            node.left.getType() == FloatType && node.right.getType() == FloatType -> BooleanType
+            node.left.getType() == IntegerType && node.right.getType() == FloatType -> BooleanType
+            node.left.getType() == FloatType && node.right.getType() == IntegerType -> BooleanType
+            node.left.getType() == StateType && node.right.getType() == StateType -> BooleanType
+            node.left.getType() == ActualNeighbourhoodType && node.right.getType() == ActualNeighbourhoodType -> BooleanType
+            node.left.getType() == ActualNeighbourhoodType && node.right.getType() is ArrayType && (node.right.getType() as ArrayType).subtype == StateType -> BooleanType
+            node.left.getType() is ArrayType && (node.left.getType() as ArrayType).subtype == StateType && node.right.getType() == ActualNeighbourhoodType -> BooleanType
+            node.left.getType() is ArrayType && node.right.getType() is ArrayType -> BooleanType
+            else -> throw TypeError()
+        })
+    }
+
+    override fun visit(node: EqualityExpr) {
+        super.visit(node)
+
+        node.setType(when {
+            node.left.getType() == BooleanType && node.right.getType() == BooleanType -> BooleanType
+            node.left.getType() == IntegerType && node.right.getType() == IntegerType -> BooleanType
+            node.left.getType() == FloatType && node.right.getType() == FloatType -> BooleanType
+            node.left.getType() == IntegerType && node.right.getType() == FloatType -> BooleanType
+            node.left.getType() == FloatType && node.right.getType() == IntegerType -> BooleanType
+            node.left.getType() == StateType && node.right.getType() == StateType -> BooleanType
+            node.left.getType() == ActualNeighbourhoodType && node.right.getType() == ActualNeighbourhoodType -> BooleanType
+            node.left.getType() == ActualNeighbourhoodType && node.right.getType() is ArrayType && (node.right.getType() as ArrayType).subtype == StateType -> BooleanType
+            node.left.getType() is ArrayType && (node.left.getType() as ArrayType).subtype == StateType && node.right.getType() == ActualNeighbourhoodType -> BooleanType
+            node.left.getType() is ArrayType && node.right.getType() is ArrayType -> BooleanType
+            else -> throw TypeError()
+        })
+    }
+
+    override fun visit(node: MoreThanExpr) {
+        super.visit(node)
+
+        node.setType(when {
+            node.left.getType() == IntegerType && node.right.getType() == IntegerType -> BooleanType
+            node.left.getType() == FloatType && node.right.getType() == FloatType -> BooleanType
+            node.left.getType() == IntegerType && node.right.getType() == FloatType -> BooleanType
+            node.left.getType() == FloatType && node.right.getType() == IntegerType -> BooleanType
+            else -> throw TypeError()
+        })
+    }
+
+    override fun visit(node: MoreEqExpr) {
+        super.visit(node)
+
+        node.setType(when {
+            node.left.getType() == IntegerType && node.right.getType() == IntegerType -> BooleanType
+            node.left.getType() == FloatType && node.right.getType() == FloatType -> BooleanType
+            node.left.getType() == IntegerType && node.right.getType() == FloatType -> BooleanType
+            node.left.getType() == FloatType && node.right.getType() == IntegerType -> BooleanType
+            else -> throw TypeError()
+        })
+    }
+
+    override fun visit(node: LessThanExpr) {
+        super.visit(node)
+
+        node.setType(when {
+            node.left.getType() == IntegerType && node.right.getType() == IntegerType -> BooleanType
+            node.left.getType() == FloatType && node.right.getType() == FloatType -> BooleanType
+            node.left.getType() == IntegerType && node.right.getType() == FloatType -> BooleanType
+            node.left.getType() == FloatType && node.right.getType() == IntegerType -> BooleanType
+            else -> throw TypeError()
+        })
+    }
+
+    override fun visit(node: LessEqExpr) {
+        super.visit(node)
+
+        node.setType(when {
+            node.left.getType() == IntegerType && node.right.getType() == IntegerType -> BooleanType
+            node.left.getType() == FloatType && node.right.getType() == FloatType -> BooleanType
+            node.left.getType() == IntegerType && node.right.getType() == FloatType -> BooleanType
+            node.left.getType() == FloatType && node.right.getType() == IntegerType -> BooleanType
+            else -> throw TypeError()
+        })
+    }
+
+    override fun visit(node: AdditionExpr) {
+        super.visit(node)
+
+        node.setType(when {
+            node.left.getType() == IntegerType && node.right.getType() == IntegerType -> IntegerType
+            node.left.getType() == FloatType && node.right.getType() == FloatType -> FloatType
+            node.left.getType() == IntegerType && node.right.getType() == FloatType -> FloatType
+            node.left.getType() == FloatType && node.right.getType() == IntegerType -> FloatType
+            else -> throw TypeError()
+        })
+    }
+
+    override fun visit(node: SubtractionExpr) {
+        super.visit(node)
+
+        node.setType(when {
+            node.left.getType() == IntegerType && node.right.getType() == IntegerType -> IntegerType
+            node.left.getType() == FloatType && node.right.getType() == FloatType -> FloatType
+            node.left.getType() == IntegerType && node.right.getType() == FloatType -> FloatType
+            node.left.getType() == FloatType && node.right.getType() == IntegerType -> FloatType
+            else -> throw TypeError()
+        })
+    }
+
+    override fun visit(node: MultiplicationExpr) {
+        super.visit(node)
+
+        node.setType(when {
+            node.left.getType() == IntegerType && node.right.getType() == IntegerType -> IntegerType
+            node.left.getType() == FloatType && node.right.getType() == FloatType -> FloatType
+            node.left.getType() == IntegerType && node.right.getType() == FloatType -> FloatType
+            node.left.getType() == FloatType && node.right.getType() == IntegerType -> FloatType
+            else -> throw TypeError()
+        })
+    }
+
+    override fun visit(node: DivisionExpr) {
+        super.visit(node)
+
+        node.setType(when {
+            node.left.getType() == IntegerType && node.right.getType() == IntegerType -> IntegerType
+            node.left.getType() == FloatType && node.right.getType() == FloatType -> FloatType
+            node.left.getType() == IntegerType && node.right.getType() == FloatType -> FloatType
+            node.left.getType() == FloatType && node.right.getType() == IntegerType -> FloatType
+            else -> throw TypeError()
+        })
+    }
+
+    override fun visit(node: PreIncExpr) {
+        super.visit(node)
+
+        node.setType(when(node.value.getType()) {
+            IntegerType -> IntegerType
+            FloatType -> FloatType
+            else -> throw TypeError()
+        })
+    }
+
+    override fun visit(node: PreDecExpr) {
+        super.visit(node)
+
+        node.setType(when(node.value.getType()) {
+            IntegerType -> IntegerType
+            FloatType -> FloatType
+            else -> throw TypeError()
+        })
+    }
+
+    override fun visit(node: PostIncExpr) {
+        super.visit(node)
+
+        node.setType(when(node.value.getType()) {
+            IntegerType -> IntegerType
+            FloatType -> FloatType
+            else -> throw TypeError()
+        })
+    }
+
+    override fun visit(node: PostDecExpr) {
+        super.visit(node)
+
+        node.setType(when(node.value.getType()) {
+            IntegerType -> IntegerType
+            FloatType -> FloatType
+            else -> throw TypeError()
+        })
+    }
+
+    override fun visit(node: PositiveExpr) {
+        super.visit(node)
+
+        node.setType(when(node.value.getType()) {
+            IntegerType -> IntegerType
+            FloatType -> FloatType
+            else -> throw TypeError()
+        })
+    }
+
+    override fun visit(node: NegativeExpr) {
+        super.visit(node)
+
+        node.setType(when(node.value.getType()) {
+            IntegerType -> IntegerType
+            FloatType -> FloatType
+            else -> throw TypeError()
+        })
+    }
+
+    override fun visit(node: InverseExpr) {
+        super.visit(node)
+
+        if (node.value.getType() != BooleanType) {
+            throw TypeError()
+        }
+
+        node.setType(BooleanType)
+    }
+
+    override fun visit(node: ArrayLookupExpr) {
+        super.visit(node)
+
+        node.setType(symbolTableSession.getSymbolType(node.ident))
+    }
+
+    override fun visit(node: ArrayBodyExpr) {
+        super.visit(node)
+
+        /*
+        * Scenarios that has to be checked:
+        *
+        * Has declared type, and has values -> Check value consistency, and check declared type matches values type
+        * Has declared type, but no values  -> Used declared type
+        * No declared type, and has values  -> Check value consistency
+        * No declared type, and no values   -> Impossible
+        * */
+
+        val valuesType: Type?
+        if (node.values.isEmpty()) {
+            // No values specified, nothing to check against
+            valuesType = null
+        } else {
+            // Check consistency of types
+            val types = node.values.map { it.getType() }.toList()
+            if (types.distinct().count() > 1) {
+                // ToDo int to float conversion
+                throw TypeError()
+            }
+            valuesType = types.first() // Pick any one because we have already checked they are identical
+        }
+
+        // ToDo implicit conversion, declaredType == float, and valuesType == integer -> type = float
+        node.setType(when {
+            node.declaredType != null && node.values.isNotEmpty() -> {
+                if (node.declaredType != valuesType) {
+                    throw TypeError()
+                }
+                node.declaredType
+            }
+            node.declaredType != null && node.values.isEmpty() -> node.declaredType
+            node.declaredType == null && node.values.isNotEmpty() -> valuesType
+            node.declaredType == null && node.values.isEmpty() -> throw TypeError()
+            else -> throw AssertionError("This case should never be hit")
+        })
+    }
+
+    override fun visit(node: ParenExpr) {
+        super.visit(node)
+
+        node.setType(node.expr.getType())
+    }
+
+    override fun visit(node: NamedExpr) {
+        node.setType(symbolTableSession.getSymbolType(node.ident))
+    }
+
+    override fun visit(node: ModuloExpr) {
+        super.visit(node)
+
+        node.setType(when {
+            node.left.getType() == IntegerType && node.right.getType() == IntegerType -> IntegerType
+            node.left.getType() == FloatType && node.right.getType() == FloatType -> FloatType
+            node.left.getType() == IntegerType && node.right.getType() == FloatType -> FloatType
+            node.left.getType() == FloatType && node.right.getType() == IntegerType -> FloatType
+            else -> throw TypeError()
+        })
+    }
+
+    override fun visit(node: FuncExpr) {
+        super.visit(node)
+
+        node.setType(symbolTableSession.getSymbolType(node.ident))
+    }
+
+    override fun visit(node: ConstDecl) {
+        super.visit(node)
+
+        node.type = node.expr.getType()
+    }
+
+    // FuncDecl is handled in ParseTreeValueWalker
+
+    override fun visit(node: AssignStmt) {
+        super.visit(node)
+
+        node.setType(node.expr.getType())
+    }
+}

--- a/compiler/src/main/kotlin/walkers/value.kt
+++ b/compiler/src/main/kotlin/walkers/value.kt
@@ -83,10 +83,10 @@ class LiteralExtractorVisitor : BaseASTVisitor() {
     override fun visit(node: FuncDecl) {
         super.visit(node)
 
-        node.args = node.ctx.func_decl_arg().map { FunctionArgs(it.IDENT().text, it.type_ident().text) }.toList()
+        node.args = node.ctx.func_decl_arg().map { FunctionArgs(it.IDENT().text, typeFromCtx(it.type_ident())) }.toList()
 
         node.ident = node.ctx.func_ident().text
-        node.returnType = node.ctx.type_ident().text
+        node.returnType = typeFromCtx(node.ctx.type_ident())
     }
 
     override fun visit(node: StateDecl) {

--- a/compiler/src/main/kotlin/walkers/visitor.kt
+++ b/compiler/src/main/kotlin/walkers/visitor.kt
@@ -87,7 +87,7 @@ interface ASTVisitor {
 
     fun visit(node: PreDecStmt)
 
-    fun visit(ndoe: PostDecStmt)
+    fun visit(node: PostDecStmt)
 
     fun visit(node: ReturnStmt)
     fun visit(node: AST)
@@ -341,11 +341,33 @@ abstract class BaseASTVisitor: ASTVisitor {
         // no-op
     }
 
-    override fun visit(ndoe: PostDecStmt) {
+    override fun visit(node: PostDecStmt) {
         // no-op
     }
 
     override fun visit(node: ReturnStmt) {
         visit(node.value)
+    }
+}
+
+open class ScopedASTVisitor(symbolTable: Table): BaseASTVisitor() {
+    protected val symbolTableSession = ViewingSymbolTableSession(symbolTable = symbolTable)
+
+    override fun visit(node: StateDecl) {
+        symbolTableSession.openScope()
+        super.visit(node)
+        symbolTableSession.closeScope()
+    }
+
+    override fun visit(node: FuncDecl) {
+        symbolTableSession.openScope()
+        super.visit(node)
+        symbolTableSession.closeScope()
+    }
+
+    override fun visit(node: ConditionalBlock) {
+        symbolTableSession.openScope()
+        super.visit(node)
+        symbolTableSession.closeScope()
     }
 }

--- a/compiler/src/main/resources/stress.cell
+++ b/compiler/src/main/resources/stress.cell
@@ -6,13 +6,13 @@ world {
 
 const bar = false;
 
-const arr1 = [3]boolean{ true, false, true };
-const arr2 = [2]boolean{ true, true };
-const arr3 = []boolean{ false, true };
+const arr1 = [3]bool{ true, false, true };
+const arr2 = [2]bool{ true, true };
+const arr3 = []bool{ false, true };
 
-const t1 = [2][2]boolean{};
-const t2 = [2]boolean{};
-const t3 = [2]integer{};
+const t1 = [2][2]bool{};
+const t2 = [2]bool{};
+const t3 = [2]int{};
 const t4 = [2]float{};
 const t5 = [2]neighbourhood{};
 const t6 = [2]state{};
@@ -42,7 +42,7 @@ state s1 (255, 0, 12) {
     //let u = { 1, 2, 3 };
     let v = 2 * (123 + 321);
     let w = bar;
-    let x = baz(132);
+    //let x = baz(132);
     let y = #;
 
     let bt = true;
@@ -69,7 +69,7 @@ state s1 (255, 0, 12) {
     return a;
 }
 
-function f1(integer a, integer b) boolean {
+function f1(int a, int b) bool {
     return a + b;
 }
 

--- a/compiler/src/main/resources/stress.cell
+++ b/compiler/src/main/resources/stress.cell
@@ -12,7 +12,7 @@ const arr3 = []boolean{ false, true };
 
 const t1 = [2][2]boolean{};
 const t2 = [2]boolean{};
-const t3 = [2]number{};
+const t3 = [2]integer{};
 const t4 = [2]float{};
 const t5 = [2]neighbourhood{};
 const t6 = [2]state{};
@@ -69,7 +69,7 @@ state s1 (255, 0, 12) {
     return a;
 }
 
-function f1(number a, number b) boolean {
+function f1(integer a, integer b) boolean {
     return a + b;
 }
 

--- a/compiler/src/test/kotlin/test.kt
+++ b/compiler/src/test/kotlin/test.kt
@@ -2,7 +2,10 @@ package dk.aau.cs.d409f19
 
 import dk.aau.cs.d409f19.antlr.CellmataLexer
 import dk.aau.cs.d409f19.antlr.CellmataParser
+import dk.aau.cs.d409f19.cellumata.walkers.TypeChecker
 import dk.aau.cs.d409f19.cellumata.ast.reduce
+import dk.aau.cs.d409f19.cellumata.walkers.LiteralExtractorVisitor
+import dk.aau.cs.d409f19.cellumata.walkers.ScopeCheckVisitor
 import org.antlr.v4.runtime.ANTLRFileStream
 import org.antlr.v4.runtime.CommonTokenStream
 import org.junit.jupiter.api.Test
@@ -19,5 +22,13 @@ class CompilerTests {
         val startContext = parser.start()
 
         val ast = reduce(startContext)
+
+        LiteralExtractorVisitor().visit(ast)
+
+        val symbolWalker = ScopeCheckVisitor()
+        symbolWalker.visit(ast)
+        val symbolTable = symbolWalker.getSymbolTable()
+
+        TypeChecker(symbolTable).visit(ast)
     }
 }


### PR DESCRIPTION
Support for implicit conversions are missing.
Added float and integer tokens to grammar.
Changed the TypedNode interface to allow for more classes to contain a type, and to have a generic way of accessing that type.
Move type of literals to their class definition.
Deprecated SymbolTable in favor of the new CreatingSymbolTableSession.
Removed typeFromString in favor of typeFromCtx.
Added ScopedASTVisitor to traverse the AST while automaticly opening and closing scopes.
Updated test to include ParseTreeValueWalker, SymbolWalker, and TypeChecker.
Changed type names to use the new short version.