### PR TITLE
Remove positive expression from language

### DIFF
--- a/compiler/src/main/antlr/Cellmata.g4
+++ b/compiler/src/main/antlr/Cellmata.g4
@@ -118,7 +118,6 @@ expr : '#' # stateIndexExpr
     | value=expr OP_INCREMENT # postIncExpr
     | OP_NOT value=expr # inverseExpr
     | OP_MINUS value=expr # negativeExpr
-    | OP_PLUS value=expr # positiveExpr
     | OP_DECREMENT value=expr # preDecExpr
     | OP_INCREMENT value=expr # preIncExpr
     | left=expr OP_MODULO right=expr # moduloExpr

--- a/compiler/src/main/kotlin/ast/ast.kt
+++ b/compiler/src/main/kotlin/ast/ast.kt
@@ -68,8 +68,6 @@ data class PostIncExpr(val ctx: CellmataParser.PostIncExprContext, val value: Ex
 
 data class PostDecExpr(val ctx: CellmataParser.PostDecExprContext, val value: Expr) : Expr()
 
-data class PositiveExpr(val ctx: CellmataParser.PositiveExprContext, val value: Expr) : Expr()
-
 data class NegativeExpr(val ctx: CellmataParser.NegativeExprContext, val value: Expr) : Expr()
 
 data class InverseExpr(val ctx: CellmataParser.InverseExprContext, val value: Expr) : Expr()

--- a/compiler/src/main/kotlin/ast/reduce.kt
+++ b/compiler/src/main/kotlin/ast/reduce.kt
@@ -79,10 +79,6 @@ private fun reduceExpr(node: ParseTree): Expr {
             ctx = node,
             value = reduceExpr(node.value)
         )
-        is CellmataParser.PositiveExprContext -> PositiveExpr(
-            ctx = node,
-            value = reduceExpr(node.value)
-        )
         is CellmataParser.NegativeExprContext -> NegativeExpr(
             ctx = node,
             value = reduceExpr(node.value)

--- a/compiler/src/main/kotlin/walkers/visitor.kt
+++ b/compiler/src/main/kotlin/walkers/visitor.kt
@@ -49,8 +49,6 @@ interface ASTVisitor {
 
     fun visit(node: PostDecExpr)
 
-    fun visit(node: PositiveExpr)
-
     fun visit(node: NegativeExpr)
 
     fun visit(node: InverseExpr)
@@ -153,7 +151,6 @@ abstract class BaseASTVisitor: ASTVisitor {
             is PreDecExpr -> visit(node)
             is PostIncExpr -> visit(node)
             is PostDecExpr -> visit(node)
-            is PositiveExpr -> visit(node)
             is NegativeExpr -> visit(node)
             is InverseExpr -> visit(node)
             is ArrayLookupExpr -> visit(node)
@@ -241,10 +238,6 @@ abstract class BaseASTVisitor: ASTVisitor {
     }
 
     override fun visit(node: PostDecExpr) {
-        visit(node.value)
-    }
-
-    override fun visit(node: PositiveExpr) {
         visit(node.value)
     }
 

--- a/compiler/src/main/resources/stress.cell
+++ b/compiler/src/main/resources/stress.cell
@@ -35,7 +35,7 @@ state s1 (255, 0, 12) {
     let o = --2;
     let p1 = 2++;
     let p2 = 2--;
-    let q = +n;
+    //let q = +n;
     let r = -n;
     let s = !true;
     let t = baz[0];


### PR DESCRIPTION
Removed positive expression from grammar, compiler, and `stress.cell`.
Resolves #48.