### PR TITLE
Removed pre- and post increment/decrement

### DIFF
--- a/compiler/src/main/antlr/Cellmata.g4
+++ b/compiler/src/main/antlr/Cellmata.g4
@@ -30,7 +30,7 @@ state_rgb : PAREN_START red=integer_literal LIST_SEP green=integer_literal LIST_
 
 // Code
 code_block : BLOCK_START stmt* BLOCK_END ;
-stmt : (if_stmt | become_stmt | assign_stmt | increment_stmt | decrement_stmt | return_stmt | for_stmt | break_stmt | continue_stmt) ;
+stmt : (if_stmt | become_stmt | assign_stmt | return_stmt | for_stmt | break_stmt | continue_stmt) ;
 
 assign_stmt : assignment END ;
 assignment : STMT_LET? (var_ident | array_lookup) ASSIGN expr ;
@@ -41,14 +41,6 @@ if_stmt_if : STMT_IF if_stmt_block ;
 if_stmt_block : PAREN_START if_stmt_condition PAREN_END code_block ;
 if_stmt_else : STMT_ELSE code_block ;
 become_stmt : STMT_BECOME state=expr END ;
-increment_stmt
-    : modifiable_ident OP_INCREMENT END # postIncStmt
-    | OP_INCREMENT modifiable_ident END # preIncStmt
-    ;
-decrement_stmt
-    : modifiable_ident OP_DECREMENT END # postDecStmt
-    | OP_DECREMENT modifiable_ident END # preDecStmt
-    ;
 return_stmt : STMT_RETURN expr END ;
 
 //For-loop
@@ -114,13 +106,9 @@ expr : '#' # stateIndexExpr
     | PAREN_START value=expr PAREN_END # parenExpr
     | value=array_value # arrayValueExpr
     | value=expr SQ_BRACKET_START index=expr SQ_BRACKET_END # arrayLookupExpr
-    | value=expr OP_DECREMENT # postDecExpr
-    | value=expr OP_INCREMENT # postIncExpr
     | OP_NOT value=expr # inverseExpr
     | OP_MINUS value=expr # negativeExpr
     | OP_PLUS value=expr # positiveExpr
-    | OP_DECREMENT value=expr # preDecExpr
-    | OP_INCREMENT value=expr # preIncExpr
     | left=expr OP_MODULO right=expr # moduloExpr
     | left=expr OP_DIVIDE right=expr # divisionExpr
     | left=expr OP_MULTIPLY right=expr # multiplictionExpr
@@ -162,8 +150,6 @@ END : ';' ;
 OP_COMPARE : '==' ;
 OP_COMPARE_NOT : '!=' ;
 OP_NOT : '!' ;
-OP_INCREMENT : '++' ;
-OP_DECREMENT : '--' ;
 OP_PLUS : '+' ;
 OP_MINUS : '-' ;
 OP_MULTIPLY : '*' ;

--- a/compiler/src/main/antlr/Cellmata.g4
+++ b/compiler/src/main/antlr/Cellmata.g4
@@ -60,7 +60,6 @@ neighbourhood_code : BLOCK_START coords_decl (LIST_SEP coords_decl)* BLOCK_END ;
 coords_decl : PAREN_START integer_literal (LIST_SEP integer_literal)? PAREN_END ;
 
 // Identifiers
-modifiable_ident : var_ident | array_lookup ;
 var_ident : IDENT ;
 
 // Type declaration

--- a/compiler/src/main/kotlin/ast/ast.kt
+++ b/compiler/src/main/kotlin/ast/ast.kt
@@ -60,14 +60,6 @@ data class MultiplicationExpr(val ctx: CellmataParser.MultiplictionExprContext, 
 
 data class DivisionExpr(val ctx: CellmataParser.DivisionExprContext, val left: Expr, val right: Expr) : Expr()
 
-data class PreIncExpr(val ctx: CellmataParser.PreIncExprContext, val value: Expr) : Expr()
-
-data class PreDecExpr(val ctx: CellmataParser.PreDecExprContext, val value: Expr) : Expr()
-
-data class PostIncExpr(val ctx: CellmataParser.PostIncExprContext, val value: Expr) : Expr()
-
-data class PostDecExpr(val ctx: CellmataParser.PostDecExprContext, val value: Expr) : Expr()
-
 data class PositiveExpr(val ctx: CellmataParser.PositiveExprContext, val value: Expr) : Expr()
 
 data class NegativeExpr(val ctx: CellmataParser.NegativeExprContext, val value: Expr) : Expr()
@@ -152,13 +144,5 @@ data class BreakStmt(val ctx: CellmataParser.Break_stmtContext) : Stmt()
 data class ContinueStmt(val ctx: CellmataParser.Continue_stmtContext) : Stmt()
 
 data class BecomeStmt(val ctx: CellmataParser.Become_stmtContext, val state: Expr) : Stmt()
-
-data class PreIncStmt(val ctx: CellmataParser.PreIncStmtContext, val variable: Expr) : Stmt()
-
-data class PostIncStmt(val ctx: CellmataParser.PostIncStmtContext, val variable:  Expr) : Stmt()
-
-data class PreDecStmt(val ctx: CellmataParser.PreDecStmtContext, val variable: Expr) : Stmt()
-
-data class PostDecStmt(val ctx: CellmataParser.PostDecStmtContext, val variable: Expr) : Stmt()
 
 data class ReturnStmt(val ctx: CellmataParser.Return_stmtContext, val value: Expr) : Stmt()

--- a/compiler/src/main/kotlin/ast/mapper.kt
+++ b/compiler/src/main/kotlin/ast/mapper.kt
@@ -71,14 +71,6 @@ private fun visitExpr(node: ParseTree): Expr {
             left = visitExpr(node.left),
             right = visitExpr(node.right)
         )
-        is CellmataParser.PreIncExprContext -> PreIncExpr(
-            ctx = node,
-            value = visitExpr(node.value)
-        )
-        is CellmataParser.PreDecExprContext -> PreDecExpr(
-            ctx = node,
-            value = visitExpr(node.value)
-        )
         is CellmataParser.PositiveExprContext -> PositiveExpr(
             ctx = node,
             value = visitExpr(node.value)
@@ -88,14 +80,6 @@ private fun visitExpr(node: ParseTree): Expr {
             value = visitExpr(node.value)
         )
         is CellmataParser.InverseExprContext -> InverseExpr(
-            ctx = node,
-            value = visitExpr(node.value)
-        )
-        is CellmataParser.PostIncExprContext -> PostIncExpr(
-            ctx = node,
-            value = visitExpr(node.value)
-        )
-        is CellmataParser.PostDecExprContext -> PostDecExpr(
             ctx = node,
             value = visitExpr(node.value)
         )
@@ -172,10 +156,6 @@ private fun visitStmt(node: ParseTree): Stmt {
         is CellmataParser.Break_stmtContext -> BreakStmt(ctx = node)
         is CellmataParser.Continue_stmtContext -> ContinueStmt(ctx = node)
         is CellmataParser.Become_stmtContext -> BecomeStmt(ctx = node, state = visitExpr(node.state))
-        is CellmataParser.PreIncStmtContext -> PreIncStmt(ctx = node, variable = visitExpr(node.modifiable_ident()))
-        is CellmataParser.PostIncStmtContext -> PostIncStmt(ctx = node, variable = visitExpr(node.modifiable_ident()))
-        is CellmataParser.PreDecStmtContext -> PreDecStmt(ctx = node, variable = visitExpr(node.modifiable_ident()))
-        is CellmataParser.PostDecStmtContext -> PostDecStmt(ctx = node, variable = visitExpr(node.modifiable_ident()))
         is CellmataParser.StmtContext -> visitStmt(node.getChild(0))
         is CellmataParser.Return_stmtContext -> ReturnStmt(ctx = node, value = visitExpr(node.expr()))
         else -> throw AssertionError("Unexpected tree node")

--- a/compiler/src/main/kotlin/ast/reduce.kt
+++ b/compiler/src/main/kotlin/ast/reduce.kt
@@ -109,7 +109,6 @@ private fun reduceExpr(node: ParseTree): Expr {
         is CellmataParser.FloatLiteralContext -> reduceExpr(node.value)
         is CellmataParser.Integer_literalContext -> IntLiteral(ctx = node)
         is CellmataParser.Float_literalContext -> FloatLiteral(ctx = node)
-        is CellmataParser.Modifiable_identContext -> reduceExpr(node.getChild(0))
         is CellmataParser.Var_identContext -> NamedExpr(ctx = node)
         else -> throw AssertionError("Unexpected tree node")
     }

--- a/compiler/src/main/kotlin/walkers/type.kt
+++ b/compiler/src/main/kotlin/walkers/type.kt
@@ -170,56 +170,6 @@ class TypeChecker(symbolTable: Table) : ScopedASTVisitor(symbolTable = symbolTab
         })
     }
 
-    override fun visit(node: PreIncExpr) {
-        super.visit(node)
-
-        node.setType(when(node.value.getType()) {
-            IntegerType -> IntegerType
-            FloatType -> FloatType
-            else -> throw TypeError()
-        })
-    }
-
-    override fun visit(node: PreDecExpr) {
-        super.visit(node)
-
-        node.setType(when(node.value.getType()) {
-            IntegerType -> IntegerType
-            FloatType -> FloatType
-            else -> throw TypeError()
-        })
-    }
-
-    override fun visit(node: PostIncExpr) {
-        super.visit(node)
-
-        node.setType(when(node.value.getType()) {
-            IntegerType -> IntegerType
-            FloatType -> FloatType
-            else -> throw TypeError()
-        })
-    }
-
-    override fun visit(node: PostDecExpr) {
-        super.visit(node)
-
-        node.setType(when(node.value.getType()) {
-            IntegerType -> IntegerType
-            FloatType -> FloatType
-            else -> throw TypeError()
-        })
-    }
-
-    override fun visit(node: PositiveExpr) {
-        super.visit(node)
-
-        node.setType(when(node.value.getType()) {
-            IntegerType -> IntegerType
-            FloatType -> FloatType
-            else -> throw TypeError()
-        })
-    }
-
     override fun visit(node: NegativeExpr) {
         super.visit(node)
 

--- a/compiler/src/main/kotlin/walkers/visitor.kt
+++ b/compiler/src/main/kotlin/walkers/visitor.kt
@@ -41,14 +41,6 @@ interface ASTVisitor {
 
     fun visit(node: DivisionExpr)
 
-    fun visit(node: PreIncExpr)
-
-    fun visit(node: PreDecExpr)
-
-    fun visit(node: PostIncExpr)
-
-    fun visit(node: PostDecExpr)
-
     fun visit(node: PositiveExpr)
 
     fun visit(node: NegativeExpr)
@@ -80,14 +72,6 @@ interface ASTVisitor {
     fun visit(node: IfStmt)
 
     fun visit(node: BecomeStmt)
-
-    fun visit(node: PreIncStmt)
-
-    fun visit(node: PostIncStmt)
-
-    fun visit(node: PreDecStmt)
-
-    fun visit(ndoe: PostDecStmt)
 
     fun visit(node: ReturnStmt)
     fun visit(node: AST)
@@ -149,10 +133,6 @@ abstract class BaseASTVisitor: ASTVisitor {
             is SubtractionExpr -> visit(node)
             is MultiplicationExpr -> visit(node)
             is DivisionExpr -> visit(node)
-            is PreIncExpr -> visit(node)
-            is PreDecExpr -> visit(node)
-            is PostIncExpr -> visit(node)
-            is PostDecExpr -> visit(node)
             is PositiveExpr -> visit(node)
             is NegativeExpr -> visit(node)
             is InverseExpr -> visit(node)
@@ -228,22 +208,6 @@ abstract class BaseASTVisitor: ASTVisitor {
         visit(node.right)
     }
 
-    override fun visit(node: PreIncExpr) {
-        visit(node.value)
-    }
-
-    override fun visit(node: PreDecExpr) {
-        visit(node.value)
-    }
-
-    override fun visit(node: PostIncExpr) {
-        visit(node.value)
-    }
-
-    override fun visit(node: PostDecExpr) {
-        visit(node.value)
-    }
-
     override fun visit(node: PositiveExpr) {
         visit(node.value)
     }
@@ -302,10 +266,6 @@ abstract class BaseASTVisitor: ASTVisitor {
             is AssignStmt -> visit(node)
             is IfStmt -> visit(node)
             is BecomeStmt -> visit(node)
-            is PreIncStmt -> visit(node)
-            is PostIncStmt -> visit(node)
-            is PreDecStmt -> visit(node)
-            is PostDecStmt -> visit(node)
             is ReturnStmt -> visit(node)
         }
     }
@@ -327,22 +287,6 @@ abstract class BaseASTVisitor: ASTVisitor {
 
     override fun visit(node: BecomeStmt) {
         visit(node.state)
-    }
-
-    override fun visit(node: PreIncStmt) {
-        // no-op
-    }
-
-    override fun visit(node: PostIncStmt) {
-        // no-op
-    }
-
-    override fun visit(node: PreDecStmt) {
-        // no-op
-    }
-
-    override fun visit(ndoe: PostDecStmt) {
-        // no-op
     }
 
     override fun visit(node: ReturnStmt) {

--- a/compiler/src/main/resources/stress.cell
+++ b/compiler/src/main/resources/stress.cell
@@ -31,13 +31,14 @@ state s1 (255, 0, 12) {
     let k = 2 * 3.0;
     let l = 2 / 3.0;
     let m = 2 % 3.0;
-    let n = -n;
-    let m = !true;
-    let o = baz[0];
-    let p = 2 * (123 + 321);
-    let q = bar;
-    let r = baz(132);
-    let s = #;
+    let n = 42;
+    let o = -n;
+    let p = !true;
+    let q = baz[0];
+    let r = 2 * (123 + 321);
+    let s = bar;
+    let t = baz(132);
+    let u = #;
 
 
     let bt = true;

--- a/compiler/src/main/resources/stress.cell
+++ b/compiler/src/main/resources/stress.cell
@@ -31,19 +31,15 @@ state s1 (255, 0, 12) {
     let k = 2 * 3.0;
     let l = 2 / 3.0;
     let m = 2 % 3.0;
-    let n = ++2;
-    let o = --2;
-    let p1 = 2++;
-    let p2 = 2--;
-    let q = +n;
-    let r = -n;
-    let s = !true;
-    let t = baz[0];
-    //let u = { 1, 2, 3 };
-    let v = 2 * (123 + 321);
-    let w = bar;
-    let x = baz(132);
-    let y = #;
+    let n = +n;
+    let o = -n;
+    let p = !true;
+    let q = baz[0];
+    //let r = { 1, 2, 3 };
+    let s = 2 * (123 + 321);
+    let t = bar;
+    let u = baz(132);
+    let v = #;
 
     let bt = true;
     let bf = false;
@@ -58,11 +54,6 @@ state s1 (255, 0, 12) {
     } else {
         become s1;
     }
-
-    ++a;
-    a++;
-    --a;
-    a--;
 
     become s1;
 


### PR DESCRIPTION
Removed pre- and post increment/decrement from both grammar and compiler files. 
Removed all increments/decrements in stress.cell, and renamed variables
Resolves #52 