### PR TITLE
Fixed missing visit functions in ASTVisitor

### DIFF
--- a/compiler/src/main/antlr/Cellmata.g4
+++ b/compiler/src/main/antlr/Cellmata.g4
@@ -9,19 +9,13 @@ const_ident : IDENT ;
 // World
 world_dcl : STMT_WORLD BLOCK_START size=world_size tickrate=world_tickrate? cellsize=world_cellsize? BLOCK_END ;
 world_size : WORLD_SIZE ASSIGN width=world_size_dim (LIST_SEP height=world_size_dim)?;
-world_size_dim : integer_literal SQ_BRACKET_START world_size_dim_finite SQ_BRACKET_END # dimFinite ;
+world_size_dim : size=integer_literal SQ_BRACKET_START type=world_size_dim_finite SQ_BRACKET_END ;
 world_size_dim_finite
     : WORLD_WRAP # dimFiniteWrapping
     | WORLD_EDGE ASSIGN state=IDENT # dimFiniteEdge
     ;
-world_tickrate
-            : WORLD_TICKRATE ASSIGN world_tickrate_value # tickrate
-            ;
-world_tickrate_value : integer_literal ;
-world_cellsize
-            : WORLD_CELLSIZE ASSIGN world_cellsize_value # cellsize
-            ;
-world_cellsize_value : integer_literal ;
+world_tickrate : WORLD_TICKRATE ASSIGN value=integer_literal ;
+world_cellsize : WORLD_CELLSIZE ASSIGN value=integer_literal ;
 
 // State
 state_decl : STMT_STATE state_ident (SQ_BRACKET_START integer_literal SQ_BRACKET_END)? state_rgb code_block ;

--- a/compiler/src/main/kotlin/ast/ast.kt
+++ b/compiler/src/main/kotlin/ast/ast.kt
@@ -55,16 +55,16 @@ interface TypedNode {
     fun setType(type: Type?)
 }
 
-data class WorldDimension(val size: Int = -1, val type: WorldType = WorldType.UNDEFINED)
+data class WorldDimension(val size: Int = -1, val type: WorldType = WorldType.UNDEFINED, val edge: String?)
 
 /**
  * WorldNode represent the world definition.
  */
 data class WorldNode(
     override val ctx: CellmataParser.World_dclContext,
-    val dimensions: List<WorldDimension> = emptyList(),
-    val tickrate: Int? = null,
-    val cellSize: Int? = null
+    var dimensions: List<WorldDimension> = emptyList(),
+    var tickrate: Int? = null,
+    var cellSize: Int? = null
 ) : AST(ctx)
 
 /*
@@ -294,7 +294,7 @@ data class IfStmt(
     val elseBlock: List<Stmt>?
 ) : Stmt(ctx)
 
-data class ForStmt(override val ctx: CellmataParser.For_stmtContext, val initPart: AssignStmt, val condition: Expr, val postIterationPart: AssignStmt) : Stmt(ctx)
+data class ForStmt(override val ctx: CellmataParser.For_stmtContext, val initPart: AssignStmt, val condition: Expr, val postIterationPart: AssignStmt, val body: List<Stmt>) : Stmt(ctx)
 
 data class BreakStmt(override val ctx: CellmataParser.Break_stmtContext) : Stmt(ctx)
 

--- a/compiler/src/main/kotlin/ast/reduce.kt
+++ b/compiler/src/main/kotlin/ast/reduce.kt
@@ -180,7 +180,8 @@ private fun reduceStmt(node: ParseTree): Stmt {
             ctx = node,
             initPart = AssignStmt(node.for_init().assignment(), expr = reduceExpr(node.for_init().assignment().expr())),
             condition = reduceExpr(node.for_condition().expr()),
-            postIterationPart = AssignStmt(node.for_post_iteration().assignment(), expr = reduceExpr(node.for_post_iteration().assignment().expr()))
+            postIterationPart = AssignStmt(node.for_post_iteration().assignment(), expr = reduceExpr(node.for_post_iteration().assignment().expr())),
+            body = reduceCodeBlock(node.code_block())
         )
         is CellmataParser.Break_stmtContext -> BreakStmt(ctx = node)
         is CellmataParser.Continue_stmtContext -> ContinueStmt(ctx = node)

--- a/compiler/src/main/kotlin/visitors/valueextractor.kt
+++ b/compiler/src/main/kotlin/visitors/valueextractor.kt
@@ -154,6 +154,11 @@ class LiteralExtractorVisitor : BaseASTVisitor() {
         node.ident = node.ctx.var_ident().text
     }
 
+    /**
+     * Parse a string into a integer, or throw IntegerParisingException the string isn't a valid integer.
+     *
+     * @throws IntegerParsingException
+     */
     private fun parseInt(text: String, node: AST): Int {
         try {
             return text.toInt()
@@ -163,12 +168,15 @@ class LiteralExtractorVisitor : BaseASTVisitor() {
     }
 
     override fun visit(node: WorldNode) {
+        /**
+         * Parses a single dimension from the world size declaration list
+         */
         fun parseDimension(dim: CellmataParser.World_size_dimContext): WorldDimension {
             val type = dim.type
             return WorldDimension(
                 size = parseInt(dim.size.text, node),
                 type = when(type) {
-                    is CellmataParser.DimFiniteEdgeContext -> WorldType.EDGE // ToDo parse edge state
+                    is CellmataParser.DimFiniteEdgeContext -> WorldType.EDGE
                     is CellmataParser.DimFiniteWrappingContext -> WorldType.WRAPPING
                     else -> throw AssertionError()
                 },
@@ -182,6 +190,7 @@ class LiteralExtractorVisitor : BaseASTVisitor() {
 
         val width = parseDimension(node.ctx.size.width)
 
+        // If height is non-null their is two dimension, otherwise their is only one
         node.dimensions = if (node.ctx.size.height != null) {
             val height = parseDimension(node.ctx.size.height)
             listOf(width, height)

--- a/compiler/src/main/kotlin/visitors/valueextractor.kt
+++ b/compiler/src/main/kotlin/visitors/valueextractor.kt
@@ -155,7 +155,7 @@ class LiteralExtractorVisitor : BaseASTVisitor() {
     }
 
     /**
-     * Parse a string into a integer, or throw IntegerParisingException the string isn't a valid integer.
+     * Parse a string into a integer, or throw IntegerParsingException the string isn't a valid integer.
      *
      * @throws IntegerParsingException
      */
@@ -190,7 +190,7 @@ class LiteralExtractorVisitor : BaseASTVisitor() {
 
         val width = parseDimension(node.ctx.size.width)
 
-        // If height is non-null their is two dimension, otherwise their is only one
+        // If height is non-null it is two dimensional, otherwise it is one dimensional
         node.dimensions = if (node.ctx.size.height != null) {
             val height = parseDimension(node.ctx.size.height)
             listOf(width, height)

--- a/compiler/src/main/kotlin/visitors/visitor.kt
+++ b/compiler/src/main/kotlin/visitors/visitor.kt
@@ -80,6 +80,17 @@ interface ASTVisitor {
     fun visit(node: AST)
     fun visit(node: FloatLiteral)
     fun visit(node: ConditionalBlock)
+    fun visit(node: FunctionArgs)
+
+    fun visit(node: WorldNode)
+
+    fun visit(node: WorldDimension)
+
+    fun visit(node: ForStmt)
+
+    fun visit(node: BreakStmt)
+
+    fun visit(node: ContinueStmt)
 }
 
 /**
@@ -90,14 +101,28 @@ abstract class BaseASTVisitor: ASTVisitor {
     override fun visit(node: AST) {
         when (node) {
             is RootNode -> visit(node)
-            is WorldNode -> throw NotImplementedError()
+            is WorldNode -> visit(node)
             is Expr -> visit(node)
             is Decl -> visit(node)
             is Stmt -> visit(node)
+            is FunctionArgs -> visit(node)
         }
     }
 
+    override fun visit(node: WorldNode) {
+        node.dimensions.forEach { visit(it) }
+    }
+
+    override fun visit(node: WorldDimension) {
+        // no-op
+    }
+
+    override fun visit(node: FunctionArgs) {
+        // no-op
+    }
+
     override fun visit(node: RootNode) {
+        visit(node.world)
         node.body.forEach { visit(it) }
     }
 
@@ -127,6 +152,7 @@ abstract class BaseASTVisitor: ASTVisitor {
     }
 
     override fun visit(node: FuncDecl) {
+        node.args.forEach { visit(it) }
         node.body.forEach { visit(it) }
     }
 
@@ -154,7 +180,9 @@ abstract class BaseASTVisitor: ASTVisitor {
             is FuncExpr -> visit(node)
             is StateIndexExpr -> visit(node)
             is IntLiteral -> visit(node)
+            is FloatLiteral -> visit(node)
             is BoolLiteral -> visit(node)
+            else -> throw AssertionError()
         }
     }
 
@@ -273,6 +301,9 @@ abstract class BaseASTVisitor: ASTVisitor {
             is IfStmt -> visit(node)
             is BecomeStmt -> visit(node)
             is ReturnStmt -> visit(node)
+            is ForStmt -> visit(node)
+            is BreakStmt -> visit(node)
+            is ContinueStmt -> visit(node)
         }
     }
 
@@ -298,6 +329,21 @@ abstract class BaseASTVisitor: ASTVisitor {
 
     override fun visit(node: ReturnStmt) {
         visit(node.value)
+    }
+
+    override fun visit(node: ForStmt) {
+        visit(node.initPart)
+        visit(node.condition)
+        visit(node.postIterationPart)
+        node.body.forEach { visit(it) }
+    }
+
+    override fun visit(node: BreakStmt) {
+        // no-op
+    }
+
+    override fun visit(node: ContinueStmt) {
+        // no-op
     }
 }
 


### PR DESCRIPTION
Added new visit functions for FunctionArgs, Coordinate, WorldNode,
WorldDimension, ForStmt, BreakStmt, and ContinueStmt to ASTVisitor.
Added missing visit funtion to BaseASTVisitor for WorldNode,
WorldDimension, FunctionArgs, FloatLiteral, Coordinate, ForStmt,
BreakStmt, and ContinueStmt.
Fixed BaseASTVisitor#visit(NeighbourhoodDecl) not visiting coordinates.
Added value extraction for WorldNode and Coordinate.
Added missing body of "for" statement to ForStmt.
Added missing reduce call for "for" statement body.