### PR TITLE
Fixed null-list of children when body of program is empty

### DIFF
--- a/compiler/src/main/kotlin/ast/reduce.kt
+++ b/compiler/src/main/kotlin/ast/reduce.kt
@@ -245,7 +245,12 @@ fun reduce(node: ParserRuleContext): AST {
         is CellmataParser.StartContext -> RootNode(
             ctx = node,
             world = WorldNode(ctx = node.world_dcl()),
-            body = node.body().children.map(::reduceDecl)
+            // If number of children is zero, then return empty list, else reduce each child and return resulting list
+            body = if (node.body().childCount > 0) {
+            node.body().children.map(::reduceDecl)
+            } else {
+                listOf()
+            }
         )
         else -> { registerReduceError(node); ErrorAST(node) }
     }

--- a/compiler/src/main/kotlin/ast/reduce.kt
+++ b/compiler/src/main/kotlin/ast/reduce.kt
@@ -245,12 +245,8 @@ fun reduce(node: ParserRuleContext): AST {
         is CellmataParser.StartContext -> RootNode(
             ctx = node,
             world = WorldNode(ctx = node.world_dcl()),
-            // If number of children is zero, then return empty list, else reduce each child and return resulting list
-            body = if (node.body().childCount > 0) {
-            node.body().children.map(::reduceDecl)
-            } else {
-                listOf()
-            }
+            // Since ANTLR sets children to null instead of empty list, this should be handled through elvis operator
+            body = node.body().children?.map(::reduceDecl) ?: listOf()
         )
         else -> { registerReduceError(node); ErrorAST(node) }
     }


### PR DESCRIPTION
Trying to transform an empty list of children during reducing throws an `java.lang.IllegalStateException: node.body().children must not be null`. 

Fixed by checking if children count is zero, and returning an empty list instead of null.

Resolves #66.