### PR TITLE
Removed builtin functions from symboltable reserved words

### DIFF
--- a/compiler/src/main/kotlin/ast/symboltable.kt
+++ b/compiler/src/main/kotlin/ast/symboltable.kt
@@ -25,7 +25,7 @@ class SymbolRedefinitionError(ctx: ParserRuleContext, val ident: String) : Error
 /**
  * List of language keywords that can't be used as identifiers
  */
-private val RESERVED_SYMBOLS: List<String> = listOf(
+private val RESERVED_WORDS: List<String> = listOf(
     "world",
     "neighbourhood",
     "state",
@@ -56,7 +56,7 @@ class SymbolTable {
     fun insertSymbol(ident: String, node: AST) {
         val table = scopeStack.peek()
 
-        if (RESERVED_SYMBOLS.contains(ident) || table.symbols.containsKey(ident)) {
+        if (RESERVED_WORDS.contains(ident) || table.symbols.containsKey(ident)) {
             ErrorLogger.registerError(SymbolRedefinitionError(node.ctx, ident))
         } else {
             table.symbols[ident] = node
@@ -136,7 +136,7 @@ class CreatingSymbolTableSession(symbolTable: Table) {
     fun insertSymbol(ident: String, node: AST) {
         val table = scopeStack.peek()
 
-        if (RESERVED_SYMBOLS.contains(ident) || table.symbols.containsKey(ident)) {
+        if (RESERVED_WORDS.contains(ident) || table.symbols.containsKey(ident)) {
             ErrorLogger.registerError(SymbolRedefinitionError(node.ctx, ident))
         }
 

--- a/compiler/src/main/kotlin/ast/symboltable.kt
+++ b/compiler/src/main/kotlin/ast/symboltable.kt
@@ -41,13 +41,7 @@ private val RESERVED_SYMBOLS: List<String> = listOf(
     "let",
     "for",
     "continue",
-    "break",
-    "rand",
-    "abs",
-    "floor",
-    "ceil",
-    "sqrt",
-    "pow"
+    "break"
 )
 
 @Deprecated("Use CreatingSymbolTableSession")


### PR DESCRIPTION
This is a relic from when Cellmata should have builtin functions defined as reserved words.
Now that these should be user-defined functions, if necessary, this is faulty.