### PR TITLE
Check if AssignStmt is a declaration.

### DIFF
--- a/compiler/src/main/kotlin/ast/ast.kt
+++ b/compiler/src/main/kotlin/ast/ast.kt
@@ -268,6 +268,7 @@ data class AssignStmt(
     override val ctx: CellmataParser.AssignmentContext,
     var ident: String = MAGIC_UNDEFINED_STRING,
     val expr: Expr,
+    var isDeclaration: Boolean? = null,
     private var type: Type? = UncheckedType
 ) : Stmt(ctx), TypedNode {
     override fun getType(): Type? {

--- a/compiler/src/main/kotlin/visitors/valueextractor.kt
+++ b/compiler/src/main/kotlin/visitors/valueextractor.kt
@@ -152,6 +152,7 @@ class LiteralExtractorVisitor : BaseASTVisitor() {
     override fun visit(node: AssignStmt) {
         super.visit(node)
         node.ident = node.ctx.var_ident().text
+        node.isDeclaration = (node.ctx.STMT_LET() != null)
     }
 
     /**


### PR DESCRIPTION
Added a new field to AssignStmt that indicates that the statement is a
declaration and not just an assignment.
LiteralExtractorVisitor now check if AssignStmt is a declaration.