### PR TITLE
Fixed array lookup using string

### DIFF
--- a/compiler/src/main/kotlin/ast/ast.kt
+++ b/compiler/src/main/kotlin/ast/ast.kt
@@ -119,7 +119,7 @@ data class InverseExpr(override val ctx: CellmataParser.InverseExprContext, val 
 
 data class ArrayLookupExpr(
     override val ctx: CellmataParser.ArrayLookupExprContext,
-    val ident: String = MAGIC_UNDEFINED_STRING,
+    val ident: Expr,
     val index: Expr
 ) : Expr(ctx)
 

--- a/compiler/src/main/kotlin/ast/reduce.kt
+++ b/compiler/src/main/kotlin/ast/reduce.kt
@@ -103,6 +103,7 @@ private fun reduceExpr(node: ParseTree): Expr {
         )
         is CellmataParser.ArrayLookupExprContext -> ArrayLookupExpr(
             ctx = node,
+            ident = reduceExpr(node.value),
             index = reduceExpr(node.index)
         )
         is CellmataParser.ParenExprContext -> ParenExpr(

--- a/compiler/src/main/kotlin/visitors/typechecker.kt
+++ b/compiler/src/main/kotlin/visitors/typechecker.kt
@@ -229,7 +229,7 @@ class TypeChecker(symbolTable: Table) : ScopedASTVisitor(symbolTable = symbolTab
     override fun visit(node: ArrayLookupExpr) {
         super.visit(node)
 
-        node.setType(symbolTableSession.getSymbolType(node.ident))
+        node.setType(node.ident.getType())
     }
 
     override fun visit(node: ArrayBodyExpr) {

--- a/compiler/src/main/kotlin/visitors/visitor.kt
+++ b/compiler/src/main/kotlin/visitors/visitor.kt
@@ -255,6 +255,7 @@ abstract class BaseASTVisitor: ASTVisitor {
     }
 
     override fun visit(node: ArrayLookupExpr) {
+        visit(node.ident)
         visit(node.index)
     }
 


### PR DESCRIPTION
It should be possible to do an array lookup on any expression that could
contains a array. Previous behaviour limits you to naming variable that
should be looked through.