### PR TITLE
Added code block node

### DIFF
--- a/compiler/src/main/kotlin/ast/ast.kt
+++ b/compiler/src/main/kotlin/ast/ast.kt
@@ -205,7 +205,7 @@ data class StateDecl(
     var red: Short = -1,
     var blue: Short = -1,
     var green: Short = -1,
-    val body: List<Stmt>
+    val body: CodeBlock
 ) : Decl(ctx)
 
 /**
@@ -244,7 +244,7 @@ data class FuncDecl(
     override val ctx: CellmataParser.Func_declContext,
     var ident: String = MAGIC_UNDEFINED_STRING,
     var args: List<FunctionArgs> = emptyList(),
-    val body: List<Stmt> = emptyList(),
+    val body: CodeBlock,
     var returnType: Type = UncheckedType
 ) : Decl(ctx)
 
@@ -284,7 +284,7 @@ data class AssignStmt(
  * Represent a block in a if statement that is to be run if expr evaluates to true.
  * A ConditionalBlock can represent either the if or the elif part of an if statement.
  */
-data class ConditionalBlock(override val ctx: ParserRuleContext, val expr: Expr, val block: List<Stmt>) : AST(ctx)
+data class ConditionalBlock(override val ctx: ParserRuleContext, val expr: Expr, val block: CodeBlock) : AST(ctx)
 
 /**
  * Represent an entire if statement, including the if, the elif and the else blocks.
@@ -292,10 +292,10 @@ data class ConditionalBlock(override val ctx: ParserRuleContext, val expr: Expr,
 data class IfStmt(
     override val ctx: CellmataParser.If_stmtContext,
     val conditionals: List<ConditionalBlock>,
-    val elseBlock: List<Stmt>?
+    val elseBlock: CodeBlock?
 ) : Stmt(ctx)
 
-data class ForStmt(override val ctx: CellmataParser.For_stmtContext, val initPart: AssignStmt, val condition: Expr, val postIterationPart: AssignStmt, val body: List<Stmt>) : Stmt(ctx)
+data class ForStmt(override val ctx: CellmataParser.For_stmtContext, val initPart: AssignStmt, val condition: Expr, val postIterationPart: AssignStmt, val body: CodeBlock) : Stmt(ctx)
 
 data class BreakStmt(override val ctx: CellmataParser.Break_stmtContext) : Stmt(ctx)
 
@@ -312,6 +312,11 @@ data class BecomeStmt(override val ctx: CellmataParser.Become_stmtContext, val s
  * The return statement terminates a function call and returns a value to the caller.
  */
 data class ReturnStmt(override val ctx: CellmataParser.Return_stmtContext, val value: Expr) : Stmt(ctx)
+
+/**
+ * Represents a sequence of statements.
+ */
+data class CodeBlock(override val ctx: ParserRuleContext, val body: List<Stmt>): AST(ctx)
 
 /*
  * Error nodes are used when something goes wrong in reduce.kt and is returned by the failing function.

--- a/compiler/src/main/kotlin/ast/reduce.kt
+++ b/compiler/src/main/kotlin/ast/reduce.kt
@@ -232,10 +232,10 @@ private fun reduceDecl(node: ParseTree): Decl {
  *
  * @throws AssertionError thrown when encountering an unexpected node in the parse tree.
  */
-fun reduceCodeBlock(block: CellmataParser.Code_blockContext): List<Stmt> {
-    return block.children
+fun reduceCodeBlock(block: CellmataParser.Code_blockContext): CodeBlock {
+    return CodeBlock(block, block.children
         .filter { it !is TerminalNode } // Remove terminals
-        .map { reduceStmt(it) }
+        .map { reduceStmt(it) })
 }
 
 /**

--- a/compiler/src/main/kotlin/visitors/visitor.kt
+++ b/compiler/src/main/kotlin/visitors/visitor.kt
@@ -91,6 +91,8 @@ interface ASTVisitor {
     fun visit(node: BreakStmt)
 
     fun visit(node: ContinueStmt)
+
+    fun visit(node: CodeBlock)
 }
 
 /**
@@ -140,7 +142,7 @@ abstract class BaseASTVisitor: ASTVisitor {
     }
 
     override fun visit(node: StateDecl) {
-        node.body.forEach { visit(it) }
+        visit(node.body)
     }
 
     override fun visit(node: NeighbourhoodDecl) {
@@ -153,7 +155,7 @@ abstract class BaseASTVisitor: ASTVisitor {
 
     override fun visit(node: FuncDecl) {
         node.args.forEach { visit(it) }
-        node.body.forEach { visit(it) }
+        visit(node.body)
     }
 
     override fun visit(node: Expr) {
@@ -315,13 +317,13 @@ abstract class BaseASTVisitor: ASTVisitor {
     override fun visit(node: IfStmt) {
         node.conditionals.forEach { visit(it) }
         if (node.elseBlock != null) {
-            node.elseBlock.forEach { visit(it) }
+            visit(node.elseBlock)
         }
     }
 
     override fun visit(node: ConditionalBlock) {
         visit(node.expr)
-        node.block.forEach { stmt -> visit(stmt) }
+        visit(node.block)
     }
 
     override fun visit(node: BecomeStmt) {
@@ -336,7 +338,7 @@ abstract class BaseASTVisitor: ASTVisitor {
         visit(node.initPart)
         visit(node.condition)
         visit(node.postIterationPart)
-        node.body.forEach { visit(it) }
+        visit(node.body)
     }
 
     override fun visit(node: BreakStmt) {
@@ -345,6 +347,10 @@ abstract class BaseASTVisitor: ASTVisitor {
 
     override fun visit(node: ContinueStmt) {
         // no-op
+    }
+
+    override fun visit(node: CodeBlock) {
+        node.body.forEach { visit(it) }
     }
 }
 


### PR DESCRIPTION
Replace the use of `List<Stmt>` with the `CodeBlock` node.
Generalised the visiting of code blocks/statement lists.
Resolves #46 