### PR TITLE
Added names to types for better error messages

### DIFF
--- a/compiler/src/main/kotlin/ast/types.kt
+++ b/compiler/src/main/kotlin/ast/types.kt
@@ -6,19 +6,24 @@ import org.antlr.v4.runtime.tree.ParseTree
 /**
  * Base class for all type classes. This class should be viewed as effectively being an enum.
  */
-sealed class Type
+sealed class Type(val name: String) {
 
-object IntegerType : Type()
-object FloatType : Type()
-object BooleanType : Type()
-object StateType : Type()
-object ActualNeighbourhoodType : Type() // An evaluated neighbourhood
-data class ArrayType(val subtype: Type) : Type()
+    override fun toString(): String {
+        return name
+    }
+}
+
+object IntegerType : Type("int")
+object FloatType : Type("float")
+object BooleanType : Type("bool")
+object StateType : Type("state")
+object ActualNeighbourhoodType : Type("neighbourhood") // An evaluated neighbourhood
+data class ArrayType(val subtype: Type) : Type("array<$subtype>")
 
 /**
  * Default value for types before they're checked by the type checker
  */
-object UncheckedType : Type()
+object UncheckedType : Type("UncheckedType")
 
 /**
  * Convert a parse tree node to the type it represents


### PR DESCRIPTION
This makes it so that `toString()` uses the fields of the type-classes, instead of the FQN of the class.

(cherry picked from commit 101f9bff2de321a92ad385543f020cb1c4b96b00)