### PR TITLE
Added logic for checking correct returntype in function decleration

### DIFF
--- a/compiler/src/main/kotlin/visitors/typechecker.kt
+++ b/compiler/src/main/kotlin/visitors/typechecker.kt
@@ -15,6 +15,8 @@ class TypeError(ctx: ParserRuleContext, description: String) : ErrorFromContext(
  * Synthesizes types by moving them up the abstract syntax tree according to the type rules, and check that there is no violation of the type rules
  */
 class TypeChecker(symbolTable: Table) : ScopedASTVisitor(symbolTable = symbolTable) {
+    private var expectedReturn: Type? = null
+
     override fun visit(node: OrExpr) {
         super.visit(node)
 
@@ -305,6 +307,26 @@ class TypeChecker(symbolTable: Table) : ScopedASTVisitor(symbolTable = symbolTab
                 null
             }
         })
+    }
+
+    override fun visit(node: ReturnStmt) {
+        super.visit(node)
+
+        if (expectedReturn != node.value.getType()) {
+            node.value.setType(when {
+                node.value.getType() == IntegerType -> FloatType
+                else -> {
+                    ErrorLogger.registerError(TypeError(node.ctx, "Wrong return type (${node.value.getType()}). Expected $expectedReturn"))
+                    null
+                    }
+                }
+            )
+        }
+    }
+
+    override fun visit(node: FuncDecl) {
+        expectedReturn = node.returnType
+        super.visit(node)
     }
 
     override fun visit(node: FuncExpr) {


### PR DESCRIPTION
Added field to keep track of expected returntype from FuncDecl
If expected returntype does not match the value from ReturnStmt, register error
Implicit conversion from int to float in ReturnStmt visitor


Resolves #64
(cherry picked from commit b85f915731512b732b408a8e737e706ce8307880)


