### PR TITLE
Include filename in batch-testing of Cellmata programs

### DIFF
--- a/compiler/src/test/kotlin/batchtest.kt
+++ b/compiler/src/test/kotlin/batchtest.kt
@@ -8,8 +8,11 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import java.io.File
+import java.util.stream.Stream
+import org.junit.jupiter.api.Assertions.fail as Fail
 
 private const val passingBatchDir = "src/main/resources/compiling-programs/"
 private const val failingBatchDir = "src/main/resources/non-compiling-programs/"
@@ -31,16 +34,16 @@ class BatchTest {
         /**
          * Returns a list of strings from each '.cell' file under the compiling-programs dir
          */
-        private fun getCompilingPrograms(): List<String> {
-            val list = mutableListOf<String>()
+        private fun getCompilingPrograms(): Stream<Arguments> {
+            val list = mutableListOf<Arguments>()
             // Walk top-down
             File(passingBatchDir).walk().forEach {
                 // If it is a file and has extension 'cell'
                 if (it.isFile && it.extension == "cell") {
-                    list.add(it.readText())
+                    list.add(Arguments.of(it.name, it.readText()))
                 }
             }
-            return list
+            return list.stream()
         }
 
         /**
@@ -49,12 +52,12 @@ class BatchTest {
          */
         @ParameterizedTest
         @MethodSource("getCompilingPrograms")
-        fun batchPass(program: String) {
+        fun batchPass(filename: String, program: String) {
             compileProgram(program)
             // If any errors found, print them and throw exception
             if (ErrorLogger.hasErrors()) {
                 ErrorLogger.printAllErrors()
-                throw TerminatedCompilationException("Errors occurred in program")
+                throw TerminatedCompilationException("Errors occurred in program compilation! Filename: $filename")
             }
         }
     }
@@ -74,16 +77,16 @@ class BatchTest {
         /**
          * Returns a list of strings from each '.cell' file under the non-compiling-programs dir
          */
-        private fun getNonCompilingPrograms(): List<String> {
-            val list = mutableListOf<String>()
+        private fun getNonCompilingPrograms(): Stream<Arguments> {
+            val list = mutableListOf<Arguments>()
             // Walk top-down
             File(failingBatchDir).walk().forEach {
                 // If it is a file and has extension 'cell'
                 if (it.isFile && it.extension == "cell") {
-                    list.add(it.readText())
+                    list.add(Arguments.of(it.name, it.readText()))
                 }
             }
-            return list
+            return list.stream()
         }
 
         /**
@@ -92,10 +95,13 @@ class BatchTest {
          */
         @ParameterizedTest
         @MethodSource("getNonCompilingPrograms")
-        fun batchFail(program: String) {
+        fun batchFail(filename: String, program: String) {
             val compileData = compileProgram(program)
             // Assert that errors are found
-            assertTrue(ErrorLogger.hasErrors() || compileData.parser.numberOfSyntaxErrors > 0)
+            assertTrue(
+                ErrorLogger.hasErrors() || compileData.parser.numberOfSyntaxErrors > 0,
+                "Non-compiling program compiled! Filename: $filename"
+            )
         }
     }
 }


### PR DESCRIPTION
Refactored batch-testing of programs to include filename in error-message for better test-running output.