### PR TITLE
Array size extraction

### DIFF
--- a/compiler/src/main/antlr/Cellmata.g4
+++ b/compiler/src/main/antlr/Cellmata.g4
@@ -68,10 +68,10 @@ type_ident
 
 // Array
 array_decl : array_prefix type_ident ;
-array_value : array_prefix type_ident array_body ;
-array_body : BLOCK_START (expr (LIST_SEP expr)*)? BLOCK_END ;
-array_prefix : SQ_BRACKET_START integer_literal? SQ_BRACKET_END ;
-array_lookup: var_ident SQ_BRACKET_START expr SQ_BRACKET_END ;
+array_value_sized : array_decl array_value_literal? ;
+array_value_literal : BLOCK_START (expr (LIST_SEP expr)*)? BLOCK_END ;
+array_prefix : SQ_BRACKET_START index=integer_literal? SQ_BRACKET_END ;
+array_lookup: array=expr SQ_BRACKET_START index=expr SQ_BRACKET_END ;
 
 // Literals
 literal
@@ -94,7 +94,8 @@ expr : '#' # stateIndexExpr
     | ident=var_ident # varExpr
     | value=literal # literalExpr
     | PAREN_START value=expr PAREN_END # parenExpr
-    | value=array_value # arrayValueExpr
+    | value=array_value_sized # arraySizedValueExpr
+    | value=array_value_literal # arrayLiteralExpr
     | value=expr SQ_BRACKET_START index=expr SQ_BRACKET_END # arrayLookupExpr
     | OP_NOT value=expr # notExpr
     | OP_MINUS value=expr # negationExpr

--- a/compiler/src/main/kotlin/ast/ast.kt
+++ b/compiler/src/main/kotlin/ast/ast.kt
@@ -206,13 +206,20 @@ class ArrayLookupExpr(
 
 /**
  * @param ctx the context from witch this node was created from
- * @param values Elements of the array.
+ * @param body Elements of the array.
  * @param declaredType Type listed before the body/values of the array.
  */
-class ArrayBodyExpr(
+class SizedArrayExpr(
+    ctx: SourceContext,
+    val body: ArrayLiteralExpr?,
+    val declaredType: Type,
+    var declaredSize: List<Int?>
+) : Expr(ctx)
+
+class ArrayLiteralExpr(
     ctx: SourceContext,
     val values: List<Expr>,
-    val declaredType: Type
+    var size: Int = -1
 ) : Expr(ctx)
 
 class Identifier(

--- a/compiler/src/main/kotlin/ast/ast.kt
+++ b/compiler/src/main/kotlin/ast/ast.kt
@@ -219,7 +219,7 @@ class SizedArrayExpr(
 class ArrayLiteralExpr(
     ctx: SourceContext,
     val values: List<Expr>,
-    var size: Int = -1
+    var size: Int? = null
 ) : Expr(ctx)
 
 class Identifier(

--- a/compiler/src/main/kotlin/ast/reduce.kt
+++ b/compiler/src/main/kotlin/ast/reduce.kt
@@ -24,6 +24,11 @@ import org.antlr.v4.runtime.tree.TerminalNode
 val DEFAULT_CELLSIZE = 8
 val DEFAULT_TICKRATE = 10
 
+/**
+ * Get the size declared as part of the sized arrays type declaration.
+ *
+ * @return Returns a list of sizes from the type declaration, and null for any dimension which has to be inferred. Example "[10][][30]bool{}" would return 10, null, 30
+ */
 private fun getArrayDeclaredSize(array_decl: CellmataParser.Array_declContext): MutableList<Int?> {
     val l: MutableList<Int?> = if (array_decl.array_prefix().index != null) {
         mutableListOf(array_decl.array_prefix().index.text.toInt())

--- a/compiler/src/main/kotlin/ast/types.kt
+++ b/compiler/src/main/kotlin/ast/types.kt
@@ -18,7 +18,11 @@ object FloatType : Type("float")
 object BooleanType : Type("bool")
 object StateType : Type("state")
 object LocalNeighbourhoodType : Type("neighbourhood") // An evaluated neighbourhood
-data class ArrayType(val subtype: Type) : Type("array<$subtype>")
+data class ArrayType(val subtype: Type?) : Type("array<$subtype>") {
+    override fun toString(): String {
+        return "array<$subtype>"
+    }
+}
 
 /**
  * Default value for types before they're checked by the type checker

--- a/compiler/src/main/kotlin/visitors/typechecker.kt
+++ b/compiler/src/main/kotlin/visitors/typechecker.kt
@@ -235,7 +235,7 @@ class TypeChecker(symbolTable: Table) : ScopedASTVisitor(symbolTable = symbolTab
 
     /**
      * Finds the size of the largest subarray in each dimension.
-     * Note: Note if their is empty array literals in the tree, this function may return fewer dimensions than expected.
+     * Note: if there are empty array literals in the tree, this function may return fewer dimensions than expected.
      */
     private fun searchSize(node: ArrayLiteralExpr, sizes: MutableList<Int> = mutableListOf(), depth: Int = 1): MutableList<Int> {
         if (sizes.size < depth) {

--- a/compiler/src/main/kotlin/visitors/typechecker.kt
+++ b/compiler/src/main/kotlin/visitors/typechecker.kt
@@ -326,19 +326,19 @@ class TypeChecker(symbolTable: Table) : ScopedASTVisitor(symbolTable = symbolTab
                 node.declaredType
             })
 
-        val sizes = searchSize(node.body)
+        val literalSizes = searchSize(node.body)
 
         // compare sizes
-        if (sizes.size > node.declaredSize.size) {
+        if (literalSizes.size > node.declaredSize.size) {
             throw AssertionError("Type consistency check has failed, it should have already caught this")
         }
-        val finalSizes = node.declaredSize.mapIndexed { i, size ->
-            if (size == null && i >= sizes.size) {
+        val finalSizes = node.declaredSize.mapIndexed { i, declaredSize ->
+            if (declaredSize == null && i >= literalSizes.size) {
                 null
-            } else if (size == null || (i < sizes.size-1 && sizes[i] > size)) {
-                sizes[i]
+            } else if (declaredSize == null || (i < literalSizes.size-1 && literalSizes[i] > declaredSize)) {
+                literalSizes[i]
             } else {
-                size
+                declaredSize
             }
         }.toList()
 

--- a/compiler/src/main/kotlin/visitors/typechecker.kt
+++ b/compiler/src/main/kotlin/visitors/typechecker.kt
@@ -299,6 +299,8 @@ class TypeChecker(symbolTable: Table) : ScopedASTVisitor(symbolTable = symbolTab
         /**
          * Compares two types, handles nested checking for arrays.
          * Null is equal to any other type.
+         *
+         * @return Returns true if the type are the same, accounting for wildcard matching
          */
         fun compareType(type1: Type?, type2: Type?): Boolean {
             if (type1 == null || type2 == null) {

--- a/compiler/src/main/kotlin/visitors/typechecker.kt
+++ b/compiler/src/main/kotlin/visitors/typechecker.kt
@@ -313,18 +313,16 @@ class TypeChecker(symbolTable: Table) : ScopedASTVisitor(symbolTable = symbolTab
         }
 
         // ToDo implicit conversion, declaredType == float, and valuesType == integer -> type = float
-        node.setType(when {
-            node.body.values.isNotEmpty() -> {
+        node.setType(if (node.body.values.isNotEmpty()) {
                 if (node.declaredType is ArrayType && !compareType(node.declaredType.subtype, valuesType)) {
                     ErrorLogger.registerError(TypeError(node.ctx, "Cannot determine type of array since initialised values does not match the declared type."))
                     node.setType(null)
                     return
                 }
                 node.declaredType
-            }
-            node.body.values.isEmpty() -> node.declaredType
-            else -> throw AssertionError("Cannot determine type of array. This case should never be hit!")
-        })
+            } else {
+                node.declaredType
+            })
 
         val sizes = searchSize(node.body)
 

--- a/compiler/src/main/kotlin/visitors/typechecker.kt
+++ b/compiler/src/main/kotlin/visitors/typechecker.kt
@@ -233,25 +233,27 @@ class TypeChecker(symbolTable: Table) : ScopedASTVisitor(symbolTable = symbolTab
         node.setType(node.arr.getType())
     }
 
-    override fun visit(node: ArrayBodyExpr) {
+    override fun visit(node: SizedArrayExpr) {
         super.visit(node)
 
         /*
-        * Scenarios that has to be checked:
-        *
-        * Has declared type, and has values -> Check value consistency, and check declared type matches values type
-        * Has declared type, but no values  -> Used declared type
-        * No declared type, and has values  -> Check value consistency
-        * No declared type, and no values   -> Impossible
-        * */
+         * Scenarios that has to be checked:
+         *
+         * Has declared type, and has values -> Check value consistency, and check declared type matches values type
+         * Has declared type, but no values  -> Used declared type
+         */
+
+        if(node.body == null) {
+            return
+        }
 
         val valuesType: Type?
-        if (node.values.isEmpty()) {
+        if (node.body.values.isEmpty()) {
             // No values specified, nothing to check against
             valuesType = null
         } else {
             // Check consistency of types
-            val types = node.values.map { it.getType() }.toList()
+            val types = node.body.values.map { it.getType() }.toList()
             if (types.distinct().count() > 1) {
                 // ToDo int to float conversion
                 ErrorLogger.registerError(TypeError(node.ctx, "Cannot determine type of array because it is initialised with multiple types."))
@@ -261,25 +263,100 @@ class TypeChecker(symbolTable: Table) : ScopedASTVisitor(symbolTable = symbolTab
             valuesType = types.first() // Pick any one because we have already checked they are identical
         }
 
+        /**
+         * Compares two types, handles nested checking for arrays.
+         * Null is equal to any other type.
+         */
+        fun compareType(type1: Type?, type2: Type?): Boolean {
+            if (type1 == null || type2 == null) {
+                return true
+            }
+
+            if (type1 is ArrayType && type2 is ArrayType) {
+                return compareType(type1.subtype, type2.subtype)
+            }
+
+            return type1 == type2
+        }
+
         // ToDo implicit conversion, declaredType == float, and valuesType == integer -> type = float
         node.setType(when {
-            node.declaredType != null && node.values.isNotEmpty() -> {
-                if (node.declaredType != valuesType) {
+            node.body.values.isNotEmpty() -> {
+                if (node.declaredType is ArrayType && !compareType(node.declaredType.subtype, valuesType)) {
                     ErrorLogger.registerError(TypeError(node.ctx, "Cannot determine type of array since initialised values does not match the declared type."))
                     node.setType(null)
                     return
                 }
                 node.declaredType
             }
-            node.declaredType != null && node.values.isEmpty() -> node.declaredType
-            node.declaredType == null && node.values.isNotEmpty() -> valuesType
-            node.declaredType == null && node.values.isEmpty() -> {
-                ErrorLogger.registerError(TypeError(node.ctx, "Cannot determine type of array."))
-                node.setType(null)
-                return
-            }
+            node.body.values.isEmpty() -> node.declaredType
             else -> throw AssertionError("Cannot determine type of array. This case should never be hit!")
         })
+
+        fun searchSize(node: ArrayLiteralExpr, sizes: MutableList<Int> = mutableListOf(), depth: Int = 1): MutableList<Int> {
+            if (sizes.size < depth) {
+                sizes.add(node.values.size)
+            } else  if (sizes[depth-1] < node.values.size) {
+                sizes[depth-1] = node.values.size
+            }
+
+            @Suppress("NAME_SHADOWING") var sizes = sizes
+            node.values.forEach {
+                if (it is ArrayLiteralExpr) {
+                    sizes = searchSize(it, sizes, depth + 1)
+                }
+            }
+
+            return sizes
+        }
+
+
+        val sizes = searchSize(node.body)
+
+        // compare sizes
+        if (sizes.size > node.declaredSize.size) {
+            throw AssertionError("Type consistency check has failed, it should have already caught this")
+        }
+        val finalSizes = node.declaredSize.mapIndexed { i, size ->
+            if (size == null && i >= sizes.size) {
+                null
+            } else if (size == null || (i < sizes.size-1 && sizes[i] > size)) {
+                sizes[i]
+            } else {
+                size
+            }
+        }.toList()
+
+        // check that all dimensions has a size
+        finalSizes.forEach {
+            if (it == null) {
+                throw AssertionError("A dimension has undetermined size")
+            }
+        }
+
+        // push down size
+        fun pushDownSize(n: Expr, size: List<Int>) {
+            if (n is ArrayLiteralExpr) {
+                n.size = size[0]
+
+                if (n.values.size > 1) {
+                    n.values.forEach {
+                        pushDownSize(it, size.subList(1, size.size))
+                    }
+                }
+            }
+        }
+
+        pushDownSize(
+            node.body,
+            finalSizes.map {it!!}.toList()
+        )
+    }
+
+    override fun visit(node: ArrayLiteralExpr) {
+        super.visit(node)
+
+        node.setType(ArrayType(if (node.values.isEmpty()) null else node.values[0].getType()))
     }
 
     override fun visit(node: Identifier) {

--- a/compiler/src/main/kotlin/visitors/visitor.kt
+++ b/compiler/src/main/kotlin/visitors/visitor.kt
@@ -60,13 +60,15 @@ interface ASTVisitor<R> {
 
     fun visit(node: ArrayLookupExpr): R
 
-    fun visit(node: ArrayBodyExpr): R
+    fun visit(node: SizedArrayExpr): R
 
     fun visit(node: Identifier): R
 
     fun visit(node: ModuloExpr): R
 
     fun visit(node: FuncCallExpr): R
+
+    fun visit(node: ArrayLiteralExpr): R
 
     fun visit(node: StateIndexExpr): R
 
@@ -81,7 +83,7 @@ interface ASTVisitor<R> {
     fun visit(node: IfStmt): R
 
     fun visit(node: BecomeStmt): R
-  
+
     fun visit(node: ReturnStmt): R
 
     fun visit(node: AST): R
@@ -179,13 +181,14 @@ abstract class BaseASTVisitor: ASTVisitor<Unit> {
             is NegationExpr -> visit(node)
             is NotExpr -> visit(node)
             is ArrayLookupExpr -> visit(node)
-            is ArrayBodyExpr -> visit(node)
+            is SizedArrayExpr -> visit(node)
             is Identifier -> visit(node)
             is FuncCallExpr -> visit(node)
             is StateIndexExpr -> visit(node)
             is IntLiteral -> visit(node)
             is FloatLiteral -> visit(node)
             is BoolLiteral -> visit(node)
+            is ArrayLiteralExpr -> visit(node)
             else -> throw AssertionError()
         }
     }
@@ -299,7 +302,14 @@ abstract class BaseASTVisitor: ASTVisitor<Unit> {
         visit(node.index)
     }
 
-    override fun visit(node: ArrayBodyExpr) {
+    override fun visit(node: SizedArrayExpr) {
+        if (node.body == null) {
+            return
+        }
+        visit(node.body)
+    }
+
+    override fun visit(node: ArrayLiteralExpr) {
         node.values.forEach { visit(it) }
     }
 

--- a/compiler/src/main/resources/non-compiling-programs/stress.cell
+++ b/compiler/src/main/resources/non-compiling-programs/stress.cell
@@ -6,9 +6,12 @@ world {
 
 const bar = false;
 
+const arr0 = [3]bool;
 const arr1 = [3]bool{ true, false, true };
 const arr2 = [2]bool{ true, true };
 const arr3 = []bool{ false, true };
+const arr4 = [][]bool{ { true, false }, { false, false } };
+const arr5 = [][]float{ {}, {} };
 
 const t1 = [2][2]bool{};
 const t2 = [2]bool{};
@@ -23,11 +26,6 @@ state s1 (255, 0, 12) {
     let c = true == false;
     let d = true != false;
     let e = 2 > 3.0;
-
-    //produce error, as these three variables are undeclared
-    e = abe;
-    dec = abe;
-
     let f = 2 >= 3.0;
     let g = 2 < 3.0;
     let h = 2 <= 3.0;
@@ -39,13 +37,8 @@ state s1 (255, 0, 12) {
     let n = 42;
     let o = -n;
     let p = !true;
-
-    //baz undeclared, produces error
-    let q = baz[0];
-
     let r = 2 * (123 + 321);
     let s = bar;
-    let t = baz(132);
     let u = #;
 
 
@@ -112,8 +105,4 @@ neighbourhood n1 {
 
 neighbourhood n2 {
     (1,2)
-}
-
-neighbourhood n3 {
-    (1)
 }

--- a/compiler/src/main/resources/non-compiling-programs/stress.cell
+++ b/compiler/src/main/resources/non-compiling-programs/stress.cell
@@ -10,8 +10,9 @@ const arr0 = [3]bool;
 const arr1 = [3]bool{ true, false, true };
 const arr2 = [2]bool{ true, true };
 const arr3 = []bool{ false, true };
-const arr4 = [][]bool{ { true, false }, { false, false } };
+const arr4 = [][]bool{ { true, false }, { false } };
 const arr5 = [][]float{ {}, {} };
+const arr6 = { { false, false}, { false } };
 
 const t1 = [2][2]bool{};
 const t2 = [2]bool{};


### PR DESCRIPTION
Adds code to find, propagate, and consistency check sized arrays and array literals. Additionally stress.cell have received additions for testing this new functionality and to remove broken code that prevented it from compiling.

This functionality will be used during code generation to allocate space for arrays.