### PR TITLE
Refactor of compile functions and adjusted tests accordingly

### DIFF
--- a/compiler/src/main/kotlin/main.kt
+++ b/compiler/src/main/kotlin/main.kt
@@ -8,6 +8,7 @@ import dk.aau.cs.d409f19.cellumata.ast.reduce
 import dk.aau.cs.d409f19.cellumata.visitors.SanityChecker
 import dk.aau.cs.d409f19.cellumata.visitors.ScopeCheckVisitor
 import dk.aau.cs.d409f19.cellumata.visitors.TypeChecker
+import org.antlr.v4.runtime.CharStream
 import org.antlr.v4.runtime.CharStreams
 import org.antlr.v4.runtime.CommonTokenStream
 import java.nio.file.Path
@@ -15,34 +16,65 @@ import java.nio.file.Paths
 
 val path = Paths.get("src/main/resources/compiling-programs/skeleton.cell")
 
-fun compile(path: Path) {
+fun main() {
+    // Compile static program
+    prodCompilation(path)
+}
+
+/**
+ * Compile program from given source at path
+ */
+fun compileSource(source: Path): CompilerData {
+    // Actually compile program and return compiler-data
+    return compile(CharStreams.fromPath(source))
+}
+
+/**
+ * Compile program from given source string
+ */
+fun compileSource(source: String): CompilerData {
+    // Actually compile program and return compiler-data
+    return compile(CharStreams.fromString(source))
+}
+
+/**
+ * Compile program from given CharStream as input
+ */
+fun compile(inputStream: CharStream): CompilerData {
+    val lexer = CellmataLexer(inputStream)
+    val tokenStream = CommonTokenStream(lexer)
+    val parser = CellmataParser(tokenStream)
+
+    // Build AST
+    val startContext = parser.start()
+    val ast = reduce(startContext)
+    // Asserts that no errors has been found during the last phase
+    ErrorLogger.assertNoErrors()
+
+    // Sanity checker
+    val sanityChecker = SanityChecker()
+    sanityChecker.visit(ast)
+
+    // Symbol table and scope
+    val scopeChecker = ScopeCheckVisitor()
+    scopeChecker.visit(ast)
+    val symbolTable = scopeChecker.getSymbolTable()
+    println(symbolTable)
+    ErrorLogger.assertNoErrors()
+
+    // Type checking
+    TypeChecker(symbolTable).visit(ast)
+    ErrorLogger.assertNoErrors()
+
+    return CompilerData(parser, ast, symbolTable)
+}
+
+/**
+ * Production compile function, outputs useful information to user on errors in source and possibly the compiler itself
+ */
+fun prodCompilation(path: Path) {
     try {
-        val inputStream = CharStreams.fromPath(path)
-        val lexer = CellmataLexer(inputStream)
-        val tokenStream = CommonTokenStream(lexer)
-        val parser = CellmataParser(tokenStream)
-
-        // Build AST
-        val startContext = parser.start()
-        val ast = reduce(startContext)
-        // Asserts that no errors has been found during the last phase
-        ErrorLogger.assertNoErrors()
-
-        // Sanity checker
-        val sanityChecker = SanityChecker()
-        sanityChecker.visit(ast)
-
-        // Symbol table and scope
-        val scopeChecker = ScopeCheckVisitor()
-        scopeChecker.visit(ast)
-        val symbolTable = scopeChecker.getSymbolTable()
-        println(symbolTable)
-        ErrorLogger.assertNoErrors()
-
-        // Type checking
-        TypeChecker(symbolTable).visit(ast)
-        ErrorLogger.assertNoErrors()
-
+        compileSource(path)
     } catch (e: TerminatedCompilationException) {
 
         // Compilation failed due to errors in program code
@@ -51,16 +83,11 @@ fun compile(path: Path) {
 
     } catch (e: Exception) {
 
-        // Critical error happened, maybe something is be wrong in the compiler
-        // Printing stack trace and errors for debugging reasons
+        // Printing stack trace and errors for debugging purposes
         e.printStackTrace()
         System.err.println("Critical error occurred. Maybe something is wrong in the compiler. Emptying ErrorLogger:")
         ErrorLogger.printAllErrors(path)
     }
-}
-
-fun main() {
-    compile(path)
 }
 
 /**

--- a/compiler/src/main/kotlin/main.kt
+++ b/compiler/src/main/kotlin/main.kt
@@ -16,8 +16,10 @@ import java.nio.file.Paths
 
 val path = Paths.get("src/main/resources/compiling-programs/skeleton.cell")
 
+/**
+ * Compile static program
+ */
 fun main() {
-    // Compile static program
     prodCompilation(path)
 }
 
@@ -59,14 +61,13 @@ fun compile(inputStream: CharStream): CompilerData {
     val scopeChecker = ScopeCheckVisitor()
     scopeChecker.visit(ast)
     val symbolTable = scopeChecker.getSymbolTable()
-    println(symbolTable)
     ErrorLogger.assertNoErrors()
 
     // Type checking
     TypeChecker(symbolTable).visit(ast)
     ErrorLogger.assertNoErrors()
 
-    return CompilerData(parser, ast, symbolTable)
+    return CompilerData(parser, ast, symbolTable, ErrorLogger.hasErrors())
 }
 
 /**
@@ -95,6 +96,7 @@ fun prodCompilation(path: Path) {
  */
 data class CompilerData(
     val parser: CellmataParser,
-    val ast: AST,
-    val symbolTable: Table
+    val ast: AST? = null,
+    val symbolTable: Table? = null,
+    val hasErrors: Boolean? = null
 )

--- a/compiler/src/test/kotlin/asttest.kt
+++ b/compiler/src/test/kotlin/asttest.kt
@@ -32,8 +32,10 @@ class ASTTest {
         @ParameterizedTest
         @MethodSource("worldDeclDimensionData")
         fun worldDeclOneDimensionTest(dimSize: String) {
+
             // Get compiler data of boilerplate program with only world declaration and dimOneSize as dimSize
-            val compilerData = compileProgram(getWorldDeclString(dimSize))
+            val compilerData = compileTestProgramParserASTInsecure(getWorldDeclString(dimSize))
+
             // Casting ast to RootNode
             val rootNode = compilerData.ast as RootNode
 
@@ -43,6 +45,7 @@ class ASTTest {
                 rootNode.world.dimensions[0].size,
                 "Dimension one size was not passed value of: $dimSize"
             )
+
         }
 
         /**
@@ -54,7 +57,13 @@ class ASTTest {
             // Get compiler data of boilerplate program with only world declaration and both dimensions of dimSize,
             // setting twoDimensional to true as this is required by getWorldDeclString
             val compilerData =
-                compileProgram(getWorldDeclString(dimOneSize = dimSize, dimTwoSize = dimSize, twoDimensional = true))
+                compileTestProgramParserASTInsecure(
+                    getWorldDeclString(
+                        dimOneSize = dimSize,
+                        dimTwoSize = dimSize,
+                        twoDimensional = true
+                    )
+                )
             // Casting ast to RootNode
             val rootNode = compilerData.ast as RootNode
 
@@ -86,7 +95,7 @@ class ASTTest {
         fun worldDeclTickrateTest(tickrate: String) {
             // Get compiler data of boilerplate program with only world declaration and tickrate set
             val compilerData =
-                compileProgram(getWorldDeclString(tickrate = tickrate))
+                compileTestProgramParserASTInsecure(getWorldDeclString(tickrate = tickrate))
             // Casting ast to RootNode
             val rootNode = compilerData.ast as RootNode
 
@@ -113,7 +122,7 @@ class ASTTest {
         fun worldDeclCellsizeTest(cellsize: String) {
             // Get compiler data of boilerplate program with only world declaration and cellsize set
             val compilerData =
-                compileProgram(getWorldDeclString(tickrate = cellsize))
+                compileTestProgramParserASTInsecure(getWorldDeclString(tickrate = cellsize))
             // Casting ast to RootNode
             val rootNode = compilerData.ast as RootNode
 
@@ -131,7 +140,7 @@ class ASTTest {
         @Test
         fun worldDeclOneDimensionWorldTypeTest() {
             // Get compiler data of boilerplate program with only world declaration and dimOneType as wrapping
-            val compilerData = compileProgram(getWorldDeclString(dimOneType = "wrap"))
+            val compilerData = compileTestProgramParserASTInsecure(getWorldDeclString(dimOneType = "wrap"))
             // Casting ast to RootNode
             val rootNode = compilerData.ast as RootNode
 
@@ -150,7 +159,12 @@ class ASTTest {
         fun worldDeclTwoDimensionWorldTypeTest() {
             // Get compiler data of boilerplate program with only world declaration and dimTwoType as wrapping,
             // setting twoDimensional to true as this is required by getWorldDeclString
-            val compilerData = compileProgram(getWorldDeclString(dimTwoType = "wrap", twoDimensional = true))
+            val compilerData = compileTestProgramParserASTInsecure(
+                getWorldDeclString(
+                    dimTwoType = "wrap",
+                    twoDimensional = true
+                )
+            )
             // Casting ast to RootNode
             val rootNode = compilerData.ast as RootNode
 
@@ -160,6 +174,7 @@ class ASTTest {
                 rootNode.world.dimensions[1].type,
                 "Dimension one world type was not 'wrap'"
             )
+
         }
     }
 
@@ -183,7 +198,7 @@ class ASTTest {
         @MethodSource("constDeclIntegerData")
         fun constDeclIntegerTest(value: String) {
             // Get AST for boilerplate program with only world declaration and constant declaration
-            val compilerData = compileProgram(getWorldDeclString() + "\n\n" + getConstDeclString(value = value))
+            val compilerData = compileTestProgramInsecure(getWorldDeclString() + "\n\n" + getConstDeclString(value = value))
 
 
             // Cast first body of rootNode to ConstDecl
@@ -206,7 +221,7 @@ class ASTTest {
         @ValueSource(strings = ["true", "false"])
         fun constDeclBooleanTest(value: String) {
             // Get AST for boilerplate program with only world declaration and constant declaration
-            val compilerData = compileProgram(getWorldDeclString() + "\n\n" + getConstDeclString(value = value))
+            val compilerData = compileTestProgramInsecure(getWorldDeclString() + "\n\n" + getConstDeclString(value = value))
 
             // Cast first body of rootNode to ConstDecl
             val const = (compilerData.ast as RootNode).body[0] as ConstDecl
@@ -228,7 +243,7 @@ class ASTTest {
         @ValueSource(strings = ["3.14159", "1000.99", "123456.789"])
         fun constDeclFloatTest(value: String) {
             // Get AST for boilerplate program with only world declaration and constant declaration
-            val compilerData = compileProgram(getWorldDeclString() + "\n\n" + getConstDeclString(value = value))
+            val compilerData = compileTestProgramInsecure(getWorldDeclString() + "\n\n" + getConstDeclString(value = value))
 
             // Cast first body of rootNode to ConstDecl
             val const = (compilerData.ast as RootNode).body[0] as ConstDecl
@@ -254,7 +269,7 @@ class ASTTest {
         @Test
         fun stateDeclTest() {
             // Get AST for boilerplate program
-            val compilerData = compileProgram(getBoilerplateProgramString())
+            val compilerData = compileTestProgramParserASTInsecure(getBoilerplateProgramString())
 
             // Second body of RootNode should be StateDecl
             val state = (compilerData.ast as RootNode).body[1] as StateDecl
@@ -292,7 +307,7 @@ class ASTTest {
         @MethodSource("stateDeclIdentifierData")
         fun stateDeclIdentifierTest(identifier: String) {
             // Get AST for boilerplate program
-            val compilerData = compileProgram(getWorldDeclString() + getStateDeclString(ident = identifier))
+            val compilerData = compileTestProgramParserASTInsecure(getWorldDeclString() + getStateDeclString(ident = identifier))
 
             // First body of RootNode should be StateDecl
             val state = (compilerData.ast as RootNode).body[0] as StateDecl

--- a/compiler/src/test/kotlin/batchtest.kt
+++ b/compiler/src/test/kotlin/batchtest.kt
@@ -2,11 +2,11 @@ package dk.aau.cs.d409f19
 
 import dk.aau.cs.d409f19.cellumata.ErrorLogger
 import dk.aau.cs.d409f19.cellumata.TerminatedCompilationException
-import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
+import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 import java.io.File
@@ -50,7 +50,7 @@ class BatchTest {
         @ParameterizedTest
         @MethodSource("getCompilingPrograms")
         fun batchPass(program: String) {
-            compileProgram(program)
+            compileTestProgram(program)
             // If any errors found, print them and throw exception
             if (ErrorLogger.hasErrors()) {
                 ErrorLogger.printAllErrors()
@@ -93,9 +93,7 @@ class BatchTest {
         @ParameterizedTest
         @MethodSource("getNonCompilingPrograms")
         fun batchFail(program: String) {
-            val compileData = compileProgram(program)
-            // Assert that errors are found
-            assertTrue(ErrorLogger.hasErrors() || compileData.parser.numberOfSyntaxErrors > 0)
+            assertThrows<TerminatedCompilationException> { compileTestProgram(program) }
         }
     }
 }

--- a/compiler/src/test/kotlin/symboltest.kt
+++ b/compiler/src/test/kotlin/symboltest.kt
@@ -65,7 +65,7 @@ class SymbolTest {
 
     /**
      * Returns the list of reserved words for testing data. Note that this cannot be passed to test by:
-     * @ValueSource("strings = RESERVED_WORDS") as JUnit5 complains that the source is not compileSource-time static
+     * '@ValueSource("strings = RESERVED_WORDS")' as JUnit5 complains that the source is not compile-time static
      */
     fun parserReservedSymbolsData(): List<String> {
         return RESERVED_WORDS

--- a/compiler/src/test/kotlin/symboltest.kt
+++ b/compiler/src/test/kotlin/symboltest.kt
@@ -43,11 +43,13 @@ class SymbolTest {
     fun assignStmtLiteralPassTest(value: String) {
 
         val compilerData =
-            compileProgram(getWorldDeclString() + "\n\n" + getStateDeclString(body = "let x = $value;"))
+            compileTestProgram(getWorldDeclString() + "\n\n" + getStateDeclString(body = "let x = $value;"))
+
+        // Ensure that symbol table actually exists
+        assertNotNull(compilerData.symbolTable)
 
         // Get SymbolTable for first subscope, which is first StateDecl
-        val stateSymbolTable = compilerData.symbolTable.tables[0]
-
+        val stateSymbolTable = compilerData.symbolTable!!.tables[0]
 
         // Assert identifier of variable is contained in first symbol scope
         assertTrue(stateSymbolTable.symbols.containsKey("x"))
@@ -63,7 +65,7 @@ class SymbolTest {
 
     /**
      * Returns the list of reserved words for testing data. Note that this cannot be passed to test by:
-     * @ValueSource("strings = RESERVED_WORDS") as JUnit5 complains that the source is not compile-time static
+     * @ValueSource("strings = RESERVED_WORDS") as JUnit5 complains that the source is not compileSource-time static
      */
     fun parserReservedSymbolsData(): List<String> {
         return RESERVED_WORDS
@@ -118,7 +120,7 @@ class SymbolTest {
         }
 
         // Compile boilerplate program with state having the constructed body
-        compileProgram(getWorldDeclString() + getStateDeclString(body = stringBuilder.toString()))
+        compileTestProgramParserASTInsecure(getWorldDeclString() + getStateDeclString(body = stringBuilder.toString()))
 
         // For each error recorded, assert that error is of SymbolRedefinitionError-type and with given identifier
         ErrorLogger.allErrors().forEach {
@@ -136,6 +138,8 @@ class SymbolTest {
             } catch (e: AssertionFailedError) {
                 fail("AssertionFailedError: $it was not a SymbolRedefinitionError")
             }
+
         }
+
     }
 }


### PR DESCRIPTION
Now both test and production uses the same compile-functions - mostly - since there's a need for unsafe compilation for some internal testing. Major refactoring of *production*-compilation has happened as a result.

These unsafe compile-functions for testing does not assert for no errors between phases. Since this may introduce strange exceptions, multiple unsafe compile-functions are introduced to only complete the compilation process to some extent.

Resolves #95 