### PR TITLE
Pretty printer 

### DIFF
--- a/compiler/src/main/kotlin/main.kt
+++ b/compiler/src/main/kotlin/main.kt
@@ -32,11 +32,6 @@ fun compile(path: Path) {
         val sanityChecker = SanityChecker()
         sanityChecker.visit(ast)
 
-        // Build pretty-printed program
-        val prettyPrinter = PrettyPrinter()
-        prettyPrinter.visit(ast)
-        prettyPrinter.print()
-
         // Symbol table and scope
         val scopeChecker = ScopeCheckVisitor()
         scopeChecker.visit(ast)
@@ -46,6 +41,11 @@ fun compile(path: Path) {
         // Type checking
         TypeChecker(symbolTable).visit(ast)
         ErrorLogger.assertNoErrors()
+
+        // Build pretty-printed program
+        val prettyPrinter = PrettyPrinter()
+        prettyPrinter.visit(ast)
+        prettyPrinter.print()
 
     } catch (e: TerminatedCompilationException) {
 

--- a/compiler/src/main/kotlin/main.kt
+++ b/compiler/src/main/kotlin/main.kt
@@ -5,6 +5,7 @@ import dk.aau.cs.d409f19.antlr.CellmataParser
 import dk.aau.cs.d409f19.cellumata.ast.AST
 import dk.aau.cs.d409f19.cellumata.ast.Table
 import dk.aau.cs.d409f19.cellumata.ast.reduce
+import dk.aau.cs.d409f19.cellumata.visitors.PrettyPrinter
 import dk.aau.cs.d409f19.cellumata.visitors.SanityChecker
 import dk.aau.cs.d409f19.cellumata.visitors.ScopeCheckVisitor
 import dk.aau.cs.d409f19.cellumata.visitors.TypeChecker
@@ -30,6 +31,11 @@ fun compile(path: Path) {
         // Sanity checker
         val sanityChecker = SanityChecker()
         sanityChecker.visit(ast)
+
+        // Build pretty-printed program
+        val prettyPrinter = PrettyPrinter()
+        prettyPrinter.visit(ast)
+        prettyPrinter.print()
 
         // Symbol table and scope
         val scopeChecker = ScopeCheckVisitor()

--- a/compiler/src/main/kotlin/visitors/prettyprinter.kt
+++ b/compiler/src/main/kotlin/visitors/prettyprinter.kt
@@ -16,6 +16,21 @@ class PrettyPrinter : BaseASTVisitor() {
         println(stringBuilder.toString())
     }
 
+    /**
+     * Print newlines for each distinct block
+     */
+    override fun visit(node: RootNode) {
+        // First print world declaration and add linebreak afterwards
+        visit(node.world)
+        stringBuilder.appendln()
+
+        // For each declaration in body, print it and add linebreak afterwards
+        node.body.forEach {
+            visit(it)
+            stringBuilder.appendln()
+        }
+    }
+
     /*
      * Declarations
      */
@@ -62,8 +77,8 @@ class PrettyPrinter : BaseASTVisitor() {
             stringBuilder.appendln("\tcellsize = ${node.cellSize}")
         }
 
-        // When done with all world declaration printing, print closing curly bracket and two newlines
-        stringBuilder.append("}\n\n")
+        // When done with all world declaration printing, print closing curly bracket and newline
+        stringBuilder.appendln("}")
 
     }
 
@@ -91,8 +106,8 @@ class PrettyPrinter : BaseASTVisitor() {
         // Print body
         visit(node.body)
 
-        // When done with printing body of state, print closing curly bracket and two newlines
-        stringBuilder.append("}\n\n")
+        // When done with printing body of state, print closing curly bracket and newline
+        stringBuilder.append("}\n")
     }
 
     /**
@@ -120,8 +135,8 @@ class PrettyPrinter : BaseASTVisitor() {
         // Print body of function
         visit(node.body)
 
-        // Print closing curly bracket and two newlines
-        stringBuilder.append("}\n\n")
+        // Print closing curly bracket and newline
+        stringBuilder.append("}\n")
     }
 
     /**

--- a/compiler/src/main/kotlin/visitors/prettyprinter.kt
+++ b/compiler/src/main/kotlin/visitors/prettyprinter.kt
@@ -146,6 +146,48 @@ class PrettyPrinter : BaseASTVisitor() {
         stringBuilder.append("${node.getType()} ${node.ident}")
     }
 
+    override fun visit(node: NeighbourhoodDecl) {
+        // Print 'neighbourhood'-keyword, identifier of neighbourhood, opening curly bracket, newline, and tab
+        stringBuilder.append("neighbourhood ${node.ident} {\n\t")
+
+        // Print all coordinates inline
+        for (n in node.coords.indices) {
+
+            // Boolean of is the current iteration at the last index
+            val isLast = node.coords.lastIndex == n
+
+            // Print each coordinate
+            visit(node.coords[n])
+
+            // Print separator for given iteration, empty if last, else given separator with space appended
+            stringBuilder.append(if (!isLast) ", " else "")
+        }
+
+        // Print newline, closing curly bracket, and newline
+        stringBuilder.append("\n}\n")
+    }
+
+    override fun visit(node: Coordinate) {
+        // Print opening parenthesis of given coordinate
+        stringBuilder.append("(")
+
+        // For each axe in given coordinates axes
+        for (n in node.axes.indices) {
+
+            // Boolean of is the current iteration at the last index
+            val isLast = node.axes.lastIndex == n
+
+            // Print each point
+            stringBuilder.append(node.axes[n])
+
+            // Print separator for given iteration, empty if last, else given separator with space appended
+            stringBuilder.append(if (!isLast) ", " else "")
+        }
+
+        // Print closing parenthesis of given coordinate
+        stringBuilder.append(")")
+    }
+
     /*
      * Statements
      */
@@ -188,8 +230,18 @@ class PrettyPrinter : BaseASTVisitor() {
         // Print function-name postfixed an opening parenthesis
         stringBuilder.append("${node.ident}(")
 
-        // Print each actual parameter
-        node.args.forEach(::visit)
+        // Print all actual parameters inline
+        for (n in node.args.indices) {
+
+            // Boolean of is the current iteration at the last index
+            val isLast = node.args.lastIndex == n
+
+            // Print each argument
+            visit(node.args[n])
+
+            // Print separator for given iteration, empty if last, else given separator with space appended
+            stringBuilder.append(if (!isLast) ", " else "")
+        }
 
         // Print closing parenthesis
         stringBuilder.append(")")

--- a/compiler/src/main/kotlin/visitors/prettyprinter.kt
+++ b/compiler/src/main/kotlin/visitors/prettyprinter.kt
@@ -1,0 +1,62 @@
+package dk.aau.cs.d409f19.cellumata.visitors
+
+import dk.aau.cs.d409f19.cellumata.ast.WorldNode
+import dk.aau.cs.d409f19.cellumata.ast.WorldType.EDGE
+import dk.aau.cs.d409f19.cellumata.ast.WorldType.WRAPPING
+
+class PrettyPrinter : BaseASTVisitor() {
+
+    // String builder for accumulating the pretty-printed program source
+    var stringBuilder = StringBuilder()
+
+    /**
+     * Print accumulated program from string builder
+     */
+    fun print() {
+        println(stringBuilder.toString())
+    }
+
+    override fun visit(node: WorldNode) {
+        // Begin world block boilerplate
+        stringBuilder.appendln("world {")
+
+        // Begin size-declaration boilerplate
+        stringBuilder.append("\tsize = ")
+
+        // For each dimension, print size and type
+        for (n in node.dimensions.indices) {
+            val isLast: Boolean = node.dimensions.lastIndex == n
+
+            // Set separator to ", " if not last, else empty
+            val separator = if (!isLast) ", " else ""
+
+            // Print size and depending on type, print both type and identifier within brackets appended by separator
+            stringBuilder.append(
+                "${node.dimensions[n].size} ${if (node.dimensions[n].type == WRAPPING) {
+                    "[wrap]$separator"
+                } else if (node.dimensions[n].type == EDGE) {
+                    "[edge=${node.dimensions[n].edge}]$separator"
+                } else {
+                    "[${node.dimensions[n].type}]$separator"
+                }
+                }"
+            )
+        }
+
+        // When done with printing dimension, add linebreak
+        stringBuilder.appendln()
+
+        // Print tickrate and cellsize if not null, this could possibly be handled nicer with Elvis operator
+        if (node.tickrate != null) {
+            stringBuilder.appendln("\ttickrate = ${node.tickrate}")
+        }
+
+        if (node.cellSize != null) {
+            stringBuilder.appendln("\tcellsize = ${node.cellSize}")
+        }
+
+        // When done with all world declaration printing, print closing curly bracket
+        stringBuilder.appendln("}")
+
+    }
+}

--- a/compiler/src/main/kotlin/visitors/prettyprinter.kt
+++ b/compiler/src/main/kotlin/visitors/prettyprinter.kt
@@ -223,6 +223,45 @@ class PrettyPrinter : BaseASTVisitor() {
         stringBuilder.appendln(";")
     }
 
+    override fun visit(node: IfStmt) {
+        // Print all conditional blocks in if-statement
+        for (n in node.conditionals.indices) {
+
+            // If first conditional, then append 'if', else 'elif'. Indent block as well
+            if (n == 0) stringBuilder.append("\tif ")
+            else stringBuilder.append(" elif ")
+
+            // Print each block of code
+            visit(node.conditionals[n])
+        }
+
+        // If else-block exists, print it indented, else put newline
+        if (node.elseBlock != null) {
+            stringBuilder.append(" else {\n\t")
+            visit(node.elseBlock)
+            stringBuilder.appendln("\t}")
+        } else {
+            stringBuilder.appendln()
+        }
+    }
+
+    override fun visit(node: ConditionalBlock) {
+        // Print opening parenthesis before conditional expression
+        stringBuilder.append("(")
+
+        // Print conditional expression
+        visit(node.expr)
+
+        // Print closing parenthesis after conditional expression, opening curly bracket, newline, and tab
+        stringBuilder.append(") {\n\t")
+
+        // Print block associated with conditional
+        visit(node.block)
+
+        // Close block with indented, closing curly bracket
+        stringBuilder.append("\t}")
+    }
+
     /*
      * Expressions
      */

--- a/compiler/src/main/kotlin/visitors/prettyprinter.kt
+++ b/compiler/src/main/kotlin/visitors/prettyprinter.kt
@@ -262,6 +262,41 @@ class PrettyPrinter : BaseASTVisitor() {
         stringBuilder.append("\t}")
     }
 
+    override fun visit(node: ForLoopStmt) {
+        // Print 'for (' keyword
+        stringBuilder.append("\tfor (")
+
+        // Print initialisation part, note omission of semicolon, as already exists due to printing of assign statement
+        visit(node.initPart)
+
+        // Print condition
+        visit(node.condition)
+
+        // Print delimiting semicolon
+        stringBuilder.append(";")
+
+        // Print post iteration part
+        visit(node.postIterationPart)
+
+        // End for-loop
+        stringBuilder.appendln(") {")
+
+        // Print body of for-loop
+        visit(node.body)
+
+        // Print closing curly bracket
+        stringBuilder.appendln("}")
+
+    }
+
+    override fun visit(node: BreakStmt) {
+        stringBuilder.appendln("break;")
+    }
+
+    override fun visit(node: ContinueStmt) {
+        stringBuilder.appendln("continue;")
+    }
+
     /*
      * Expressions
      */

--- a/compiler/src/main/kotlin/visitors/prettyprinter.kt
+++ b/compiler/src/main/kotlin/visitors/prettyprinter.kt
@@ -7,7 +7,7 @@ import dk.aau.cs.d409f19.cellumata.ast.WorldType.WRAPPING
 class PrettyPrinter : BaseASTVisitor() {
 
     // String builder for accumulating the pretty-printed program source
-    var stringBuilder = StringBuilder()
+    private var stringBuilder = StringBuilder()
 
     /**
      * Print accumulated program from string builder
@@ -251,6 +251,17 @@ class PrettyPrinter : BaseASTVisitor() {
 
         // Print division symbol with spaces padding expressions
         stringBuilder.append(" / ")
+
+        // Print right-side
+        visit(node.right)
+    }
+
+    override fun visit(node: ModuloExpr) {
+        // Print left-side first
+        visit(node.left)
+
+        // Print modulo symbol with spaces padding expressions
+        stringBuilder.append(" % ")
 
         // Print right-side
         visit(node.right)

--- a/compiler/src/main/kotlin/visitors/prettyprinter.kt
+++ b/compiler/src/main/kotlin/visitors/prettyprinter.kt
@@ -31,6 +31,7 @@ class PrettyPrinter : BaseASTVisitor() {
 
         // For each dimension, print size and type
         for (n in node.dimensions.indices) {
+
             val isLast: Boolean = node.dimensions.lastIndex == n
 
             // Set separator to ", " if not last, else empty
@@ -52,7 +53,7 @@ class PrettyPrinter : BaseASTVisitor() {
         // When done with printing dimension, add linebreak
         stringBuilder.appendln()
 
-        // Print tickrate and cellsize if not null, this could possibly be handled nicer with Elvis operator
+        // Print tickrate and cellsize if not null
         if (node.tickrate != null) {
             stringBuilder.appendln("\ttickrate = ${node.tickrate}")
         }
@@ -102,6 +103,7 @@ class PrettyPrinter : BaseASTVisitor() {
         stringBuilder.append("function ${node.ident}(")
 
         for (n in node.args.indices) {
+
             // Boolean of is the current iteration at the last index
             val isLast = node.args.lastIndex == n
 
@@ -122,6 +124,13 @@ class PrettyPrinter : BaseASTVisitor() {
         stringBuilder.append("}\n\n")
     }
 
+    /**
+     * Print a formal argument of a function declaration
+     */
+    override fun visit(node: FunctionArgument) {
+        stringBuilder.append("${node.getType()} ${node.ident}")
+    }
+
     /*
      * Statements
      */
@@ -138,7 +147,7 @@ class PrettyPrinter : BaseASTVisitor() {
 
     override fun visit(node: BecomeStmt) {
         // Begin become statement with the 'become'-keyword
-        stringBuilder.append("become ")
+        stringBuilder.append("\tbecome ")
 
         // Print state-name
         visit(node.state)
@@ -147,21 +156,19 @@ class PrettyPrinter : BaseASTVisitor() {
         stringBuilder.appendln(";")
     }
 
+    override fun visit(node: ReturnStmt) {
+        stringBuilder.append("\treturn ")
+
+        // Continue printing expression
+        visit(node.value)
+
+        // When done with printing expression, print semicolon and newline
+        stringBuilder.appendln(";")
+    }
+
     /*
      * Expressions
      */
-    override fun visit(node: BoolLiteral) {
-        stringBuilder.append(node.value)
-    }
-
-    override fun visit(node: IntLiteral) {
-        stringBuilder.append(node.value)
-    }
-
-    override fun visit(node: FloatLiteral) {
-        stringBuilder.append(node.value)
-    }
-
     override fun visit(node: FuncCallExpr) {
         // Print function-name postfixed an opening parenthesis
         stringBuilder.append("${node.ident}(")
@@ -174,14 +181,198 @@ class PrettyPrinter : BaseASTVisitor() {
     }
 
     override fun visit(node: Identifier) {
+        // Simply print spelling of identifier
         stringBuilder.append(node.spelling)
+    }
+
+    override fun visit(node: BoolLiteral) {
+        stringBuilder.append(node.value)
+    }
+
+    override fun visit(node: IntLiteral) {
+        stringBuilder.append(node.value)
+    }
+
+    override fun visit(node: FloatLiteral) {
+        stringBuilder.append(node.value)
+    }
+
+    override fun visit(node: AdditionExpr) {
+        // Print left-side first
+        visit(node.left)
+
+        // Print addition symbol with spaces padding expressions
+        stringBuilder.append(" + ")
+
+        // Print right-side
+        visit(node.right)
+    }
+
+    override fun visit(node: SubtractionExpr) {
+        // Print left-side first
+        visit(node.left)
+
+        // Print subtraction symbol with spaces padding expressions
+        stringBuilder.append(" - ")
+
+        // Print right-side
+        visit(node.right)
+    }
+
+    override fun visit(node: MultiplicationExpr) {
+        // Print left-side first
+        visit(node.left)
+
+        // Print multiplication symbol with spaces padding expressions
+        stringBuilder.append(" * ")
+
+        // Print right-side
+        visit(node.right)
+    }
+
+    override fun visit(node: DivisionExpr) {
+        // Print left-side first
+        visit(node.left)
+
+        // Print division symbol with spaces padding expressions
+        stringBuilder.append(" / ")
+
+        // Print right-side
+        visit(node.right)
     }
 
     override fun visit(node: NegationExpr) {
         stringBuilder.append("-")
+
+        // Continue printing value
+        visit(node.value)
     }
 
     override fun visit(node: NotExpr) {
         stringBuilder.append("!")
+
+        // Continue printing value
+        visit(node.value)
+    }
+
+    override fun visit(node: ArrayLookupExpr) {
+        // First print array expression
+        visit(node.arr)
+
+        // Lastly print index expression within brackets
+        stringBuilder.append("[")
+        visit(node.index)
+        stringBuilder.append("]")
+    }
+
+    /**
+     * Prints each element of the array body expression comma-separated
+     */
+    override fun visit(node: ArrayBodyExpr) {
+        // Open expression with opening curly bracket
+        stringBuilder.append("{")
+
+        for (n in node.values.indices) {
+
+            // Boolean of is the current iteration at the last index
+            val isLast = node.values.lastIndex == n
+
+            // Print each element
+            visit(node.values[n])
+
+            // Print separator for given iteration, empty if last, else given separator with space appended
+            stringBuilder.append(if (!isLast) ", " else "")
+
+        }
+        // When done with list, print closing curly bracket
+        stringBuilder.append("}")
+    }
+
+    override fun visit(node: OrExpr) {
+        // Print left-side first
+        visit(node.left)
+
+        // Print boolean 'or' symbol with spaces padding expressions
+        stringBuilder.append(" || ")
+
+        // Print right-side
+        visit(node.right)
+    }
+
+    override fun visit(node: AndExpr) {
+        // Print left-side first
+        visit(node.left)
+
+        // Print boolean 'and' symbol with spaces padding expressions
+        stringBuilder.append(" && ")
+
+        // Print right-side
+        visit(node.right)
+    }
+
+    override fun visit(node: InequalityExpr) {
+        // Print left-side first
+        visit(node.left)
+
+        // Print boolean inequality symbol with spaces padding expressions
+        stringBuilder.append(" != ")
+
+        // Print right-side
+        visit(node.right)
+    }
+
+    override fun visit(node: EqualityExpr) {
+        // Print left-side first
+        visit(node.left)
+
+        // Print boolean equality symbol with spaces padding expressions
+        stringBuilder.append(" == ")
+
+        // Print right-side
+        visit(node.right)
+    }
+
+    override fun visit(node: GreaterThanExpr) {
+        // Print left-side first
+        visit(node.left)
+
+        // Print boolean 'greater than' symbol with spaces padding expressions
+        stringBuilder.append(" > ")
+
+        // Print right-side
+        visit(node.right)
+    }
+
+    override fun visit(node: GreaterOrEqExpr) {
+        // Print left-side first
+        visit(node.left)
+
+        // Print boolean 'greater than or equal' symbol with spaces padding expressions
+        stringBuilder.append(" >= ")
+
+        // Print right-side
+        visit(node.right)
+    }
+
+    override fun visit(node: LessThanExpr) {
+        // Print left-side first
+        visit(node.left)
+
+        // Print boolean 'less than' symbol with spaces padding expressions
+        stringBuilder.append(" < ")
+
+        // Print right-side
+        visit(node.right)
+    }
+
+    override fun visit(node: LessOrEqExpr) {
+        // Print left-side first
+        visit(node.left)
+
+        // Print boolean 'less than or equal' symbol with spaces padding expressions
+        stringBuilder.append(" <= ")
+
+        // Print right-side
+        visit(node.right)
     }
 }

--- a/compiler/src/main/resources/compiling-programs/large-program.cell
+++ b/compiler/src/main/resources/compiling-programs/large-program.cell
@@ -9,6 +9,11 @@ const integer = 42;
 const floating = 42.420;
 const goodProgram = true; // May be accurate
 
+neighbourhood foobar {
+    (-1, 1), (0, 1), (1, 1),
+    (-1, 0),         (1, 0)
+}
+
 /* An explanation of the following states would be redundant
    but it's worthwhile trying out multi-line comments
    even just for the sake of writing nonsense */
@@ -40,10 +45,19 @@ state alive5 (0, 0, 0) {
 
 state alive6 (0, 0, 0) {
     let a = -foo(42);
+    let b = bar(a, true);
     become alive1;
 }
 
 // This is a silly function
 function foo(int x) int {
     return x + 42;
+}
+
+function bar(int x, bool y) int {
+    if (y) {
+        return x + 42;
+    } else {
+        return x + 420;
+    }
 }

--- a/compiler/src/main/resources/compiling-programs/large-program.cell
+++ b/compiler/src/main/resources/compiling-programs/large-program.cell
@@ -46,6 +46,10 @@ state alive5 (0, 0, 0) {
 state alive6 (0, 0, 0) {
     let a = -foo(42);
     let b = bar(a, true);
+
+    if (b != -16) {
+        become alive5;
+    }
     become alive1;
 }
 
@@ -57,7 +61,9 @@ function foo(int x) int {
 function bar(int x, bool y) int {
     if (y) {
         return x + 42;
+    } elif (!y) {
+        return x;
     } else {
-        return x + 420;
+        return x + 4;
     }
 }

--- a/compiler/src/main/resources/compiling-programs/large-program.cell
+++ b/compiler/src/main/resources/compiling-programs/large-program.cell
@@ -40,6 +40,16 @@ state alive4 (0, 0, 0) {
 
 state alive5 (0, 0, 0) {
     let a = -foo(42);
+    let x = 0;
+    for (x = 5; x >= a; x = x + 1) {
+        if (x != 0) {
+            x = -5;
+            break; 
+        } else {
+            x = 42 + 3 / 176 * 22;
+            continue;
+        }
+    }
     become alive6;
 }
 


### PR DESCRIPTION
Implemented complete pretty printer. 
Reproduces the source program faithfully* and matches indentation correctly when only one level is used. Covers all AST-nodes and is therefore complete.

*) Since for-loops make use of assignment-statements in both the initialisation- and post-iteration-parts, there will be an indentation before, and an extra linebreak after each assignment-statement.

The pretty-printed output of the updated `large-program.cell`.
```c
world {
	size = 1000 [edge=alive1], 1000 [wrap]
	tickrate = 100
	cellsize = 5
}

const boolean = false;

const integer = 42;

const floating = 42.42;

const goodProgram = true;

neighbourhood foobar {
	(-1, 1), (0, 1), (1, 1), (-1, 0), (1, 0)
}

state alive1 (0, 0, 0) {
	let a = -foo(42);
	become alive2;
}

state alive2 (0, 0, 0) {
	let a = -foo(42);
	become alive3;
}

state alive3 (0, 0, 0) {
	let a = -foo(42);
	become alive4;
}

state alive4 (0, 0, 0) {
	let a = -foo(42);
	become alive5;
}

state alive5 (0, 0, 0) {
	let a = -foo(42);
	let x = 0;
	for (	 x = 5;
x >= a;	 x = x + 1;
) {
	if (x != 0) {
	break;
	} else {
	continue;
	}
}
	become alive6;
}

state alive6 (0, 0, 0) {
	let a = -foo(42);
	let b = bar(a, true);
	if (b != -16) {
		become alive5;
	}
	become alive1;
}

function foo(int x) int {
	return x + 42;
}

function bar(int x, bool y) int {
	if (y) {
		return x + 42;
	} elif (!y) {
		return x;
	} else {
		return x + 4;
	}
}
```

Resolves #93 