### PR TITLE
Fix ordering of world declaration options and add two test-cases

### DIFF
--- a/compiler/src/main/antlr/Cellmata.g4
+++ b/compiler/src/main/antlr/Cellmata.g4
@@ -7,12 +7,16 @@ const_decl : STMT_CONST const_ident ASSIGN expr END ;
 const_ident : IDENT ;
 
 // World
-world_dcl : STMT_WORLD BLOCK_START size=world_size tickrate=world_tickrate? cellsize=world_cellsize? BLOCK_END ;
+world_dcl : STMT_WORLD BLOCK_START size=world_size world_options BLOCK_END ;
 world_size : WORLD_SIZE ASSIGN width=world_size_dim (LIST_SEP height=world_size_dim)?;
 world_size_dim : size=integer_literal SQ_BRACKET_START type=world_size_dim_finite SQ_BRACKET_END ;
 world_size_dim_finite
     : WORLD_WRAP # dimFiniteWrapping
     | WORLD_EDGE ASSIGN state=IDENT # dimFiniteEdge
+    ;
+world_options
+    : tickrate=world_tickrate? cellsize=world_cellsize?
+    | cellsize=world_cellsize? tickrate=world_tickrate?
     ;
 world_tickrate : WORLD_TICKRATE ASSIGN value=integer_literal ;
 world_cellsize : WORLD_CELLSIZE ASSIGN value=integer_literal ;

--- a/compiler/src/main/kotlin/ast/reduce.kt
+++ b/compiler/src/main/kotlin/ast/reduce.kt
@@ -278,8 +278,8 @@ fun reduce(node: ParserRuleContext): AST {
                 } else {
                     listOf(parseDimension(node.world_dcl().size.width))
                 },
-                cellSize = if (node.world_dcl().cellsize != null) node.world_dcl().cellsize.value.text.toIntOrNull() else DEFAULT_CELLSIZE,
-                tickrate = if (node.world_dcl().tickrate != null) node.world_dcl().tickrate.value?.text?.toIntOrNull() else DEFAULT_TICKRATE
+                cellSize = if (node.world_dcl().world_options().cellsize != null) node.world_dcl().world_options().cellsize.value.text.toIntOrNull() else DEFAULT_CELLSIZE,
+                tickrate = if (node.world_dcl().world_options().tickrate != null) node.world_dcl().world_options().tickrate.value?.text?.toIntOrNull() else DEFAULT_TICKRATE
             ),
             body = node.body().children?.map(::reduceDecl) ?: listOf()
         )

--- a/compiler/src/main/resources/compiling-programs/cellsize-tickrate-order.cell
+++ b/compiler/src/main/resources/compiling-programs/cellsize-tickrate-order.cell
@@ -1,0 +1,10 @@
+// Tests whether the order of tickrate and then cellsize compiles
+world {
+    size = 100 [wrap], 200 [wrap]
+    tickrate = 1
+    cellsize = 5
+}
+
+state ident (0, 0, 0) {
+    become ident;
+}

--- a/compiler/src/main/resources/compiling-programs/tickrate-cellsize-order.cell
+++ b/compiler/src/main/resources/compiling-programs/tickrate-cellsize-order.cell
@@ -1,0 +1,10 @@
+// Tests whether the order of tickrate and then cellsize in world declaration compiles
+world {
+    size = 100 [wrap], 200 [wrap]
+    tickrate = 1
+    cellsize = 5
+}
+
+state ident (0, 0, 0) {
+    become ident;
+}


### PR DESCRIPTION
Now the world declaration can take their options in any order, as long as they're declared after world size.

If more options are introduced at a later date, a rule on the form `options : (opt1 | opt2 | opt3 | ... )*` could be introduced, but this adds overhead in reduce phase and therefore the proposed solution is chosen.