### PR TITLE
Fix nullable init and post-parts of for-loop

### DIFF
--- a/compiler/src/main/kotlin/ast/ast.kt
+++ b/compiler/src/main/kotlin/ast/ast.kt
@@ -402,9 +402,9 @@ class IfStmt(
 
 class ForLoopStmt(
     ctx: SourceContext,
-    val initPart: AssignStmt,
+    val initPart: AssignStmt?,
     val condition: Expr,
-    val postIterationPart: AssignStmt,
+    val postIterationPart: AssignStmt?,
     val body: CodeBlock
 ) : Stmt(ctx)
 

--- a/compiler/src/main/kotlin/ast/reduce.kt
+++ b/compiler/src/main/kotlin/ast/reduce.kt
@@ -178,9 +178,9 @@ private fun reduceStmt(node: ParseTree): Stmt {
         )
         is CellmataParser.For_stmtContext -> ForLoopStmt(
             ctx = SourceContext(node),
-            initPart = reduceStmt(node.for_init().assignment()) as AssignStmt,
+            initPart = if (node.for_init() == null) null else reduceStmt(node.for_init().assignment()) as AssignStmt,
             condition = reduceExpr(node.for_condition().expr()),
-            postIterationPart = reduceStmt(node.for_post_iteration().assignment()) as AssignStmt,
+            postIterationPart = if (node.for_post_iteration() == null) null else reduceStmt(node.for_post_iteration().assignment()) as AssignStmt,
             body = reduceCodeBlock(node.code_block())
         )
         is CellmataParser.Break_stmtContext -> BreakStmt(ctx = SourceContext(node))

--- a/compiler/src/main/kotlin/visitors/grapher.kt
+++ b/compiler/src/main/kotlin/visitors/grapher.kt
@@ -288,9 +288,9 @@ class ASTGrapher(sink: OutputStream, private val output: PrintStream = PrintStre
     }
 
     override fun visit(node: ForLoopStmt) {
-        printNode(node, node.initPart)
+        node.initPart?.let { printNode(node, it) }
         printNode(node, node.condition)
-        printNode(node, node.postIterationPart)
+        node.postIterationPart?.let { printNode(node, it) }
         printNode(node, node.body)
         printLabel(node.body, "body")
         super.visit(node)

--- a/compiler/src/main/kotlin/visitors/symbolchecker.kt
+++ b/compiler/src/main/kotlin/visitors/symbolchecker.kt
@@ -100,12 +100,12 @@ class ScopeCheckVisitor(symbolTable: Table = Table()) : BaseASTVisitor() {
         // This way any loop-control-variables (those in the init-part) are not remade every iteration, but they are
         // removed when the loop finishes.
         symbolTableSession.openScope()
-        visit(node.initPart)
+        node.initPart?.let { visit(it) }
         visit(node.condition)
         symbolTableSession.openScope()
         visit(node.body)
         symbolTableSession.closeScope()
-        visit(node.postIterationPart)
+        node.postIterationPart?.let { visit(it) }
         symbolTableSession.closeScope()
     }
 }

--- a/compiler/src/main/kotlin/visitors/visitor.kt
+++ b/compiler/src/main/kotlin/visitors/visitor.kt
@@ -370,9 +370,9 @@ abstract class BaseASTVisitor: ASTVisitor<Unit> {
     }
 
     override fun visit(node: ForLoopStmt) {
-        visit(node.initPart)
+        node.initPart?.let { visit(it) }
         visit(node.condition)
-        visit(node.postIterationPart)
+        node.postIterationPart?.let { visit(it) }
         visit(node.body)
     }
 

--- a/compiler/src/main/resources/compiling-programs/for-loop-empty-init-post.cell
+++ b/compiler/src/main/resources/compiling-programs/for-loop-empty-init-post.cell
@@ -1,0 +1,19 @@
+world {
+    size = 100 [wrap], 200 [wrap]
+    tickrate = 1
+    cellsize = 5
+}
+
+state ident (0, 0, 0) {
+    let x = 5;
+    let even = 0;
+    
+    for (; x >= 0;) {
+        // If current number is even, increment counter
+        if (x % 2 == 0) {
+            even = even + 1;
+        }
+    }
+
+    become ident;
+}

--- a/compiler/src/test/kotlin/batchtest.kt
+++ b/compiler/src/test/kotlin/batchtest.kt
@@ -2,12 +2,9 @@ package dk.aau.cs.d409f19
 
 import dk.aau.cs.d409f19.cellumata.ErrorLogger
 import dk.aau.cs.d409f19.cellumata.TerminatedCompilationException
+import org.junit.jupiter.api.*
 import org.junit.jupiter.api.Assertions.assertTrue
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.DisplayName
-import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
-import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource


### PR DESCRIPTION
Similarly to C, Cellmata should support `for (; x <= 5;) { }`

`AssignStmt` are now nullable, but this necessitates safe-calls in all places that visit the for-loop AST node, e.g., grapher and symbolchecker. Let-statements only visit these nodes if they're not null, else they ignore them.