### PR TITLE
Improved Error handling: Added Warnings and verbosity

### DIFF
--- a/compiler/src/main/kotlin/ast/ast.kt
+++ b/compiler/src/main/kotlin/ast/ast.kt
@@ -7,17 +7,26 @@ import org.antlr.v4.runtime.Token
  * The SourceContext data class contains the position of the context in the source code from which an AST node was created.
  * @param lineNumber The line number in the source program. In the range 1..n
  * @param charPositionInLine The position of the first character of the AST node in source program. In the range 0..n-1
+ * @param text The context as the a string from the original source code
  */
-data class SourceContext(val lineNumber: Int, val charPositionInLine: Int) {
-    constructor(ctx: ParserRuleContext) : this(ctx.start.line, ctx.start.charPositionInLine)
-    constructor(token: Token) : this(token.line, token.charPositionInLine)
+data class SourceContext(
+    val lineNumber: Int,
+    val charPositionInLine: Int,
+    val text: String
+) {
+    constructor(ctx: ParserRuleContext) : this(ctx.start.line, ctx.start.charPositionInLine, ctx.text)
+    constructor(token: Token) : this(token.line, token.charPositionInLine, token.text)
+
+    override fun toString(): String {
+        return "($lineNumber:$charPositionInLine)"
+    }
 }
 
 /**
  * A special instance of SourceContext. It is used for nodes that are not from the source program, e.g. it could be
  * from the standard environment like a built-in function.
  */
-val EMPTY_CONTEXT = SourceContext(0, 0)
+val EMPTY_CONTEXT = SourceContext(0, 0, "")
 
 /**
  * Nodes that hold a value or that can produce a value should implement TypedNode to expose the type of that value

--- a/compiler/src/main/kotlin/ast/reduce.kt
+++ b/compiler/src/main/kotlin/ast/reduce.kt
@@ -1,7 +1,7 @@
 package dk.aau.cs.d409f19.cellumata.ast
 
 import dk.aau.cs.d409f19.antlr.CellmataParser
-import dk.aau.cs.d409f19.cellumata.ErrorFromContext
+import dk.aau.cs.d409f19.cellumata.CompileError
 import dk.aau.cs.d409f19.cellumata.ErrorLogger
 import dk.aau.cs.d409f19.cellumata.TerminatedCompilationException
 import org.antlr.v4.runtime.ParserRuleContext
@@ -267,9 +267,7 @@ private fun reduceDecl(node: ParseTree): Decl {
 fun parseColor(intCtx: CellmataParser.Integer_literalContext): Short {
     val value = intCtx.text.toShortOrNull()
     if (value == null || value < 0 || 255 < value) {
-        ErrorLogger.registerError(
-            ErrorFromContext(SourceContext(intCtx), "'${intCtx.text}' is not a valid colour. It must be an integer between 0 and 255.")
-        )
+        ErrorLogger += CompileError(SourceContext(intCtx), "'${intCtx.text}' is not a valid colour. It must be an integer between 0 and 255.")
     }
     return value ?: 0
 }
@@ -332,5 +330,5 @@ fun parseDimension(dim: CellmataParser.World_size_dimContext): WorldDimension {
  * after changing the grammar.
  */
 fun registerReduceError(ctx: ParserRuleContext) {
-    ErrorLogger.registerError(ErrorFromContext(SourceContext(ctx), "Unexpected parsing context (${ctx.javaClass}). Parse tree could not be mapped to AST."))
+    ErrorLogger += CompileError(SourceContext(ctx), "Unexpected parsing context (${ctx.javaClass}). Parse tree could not be mapped to AST.")
 }

--- a/compiler/src/main/kotlin/ast/symboltable.kt
+++ b/compiler/src/main/kotlin/ast/symboltable.kt
@@ -1,8 +1,7 @@
 package dk.aau.cs.d409f19.cellumata.ast
 
-import dk.aau.cs.d409f19.cellumata.ErrorFromContext
+import dk.aau.cs.d409f19.cellumata.CompileError
 import dk.aau.cs.d409f19.cellumata.ErrorLogger
-import org.antlr.v4.runtime.ParserRuleContext
 import java.util.*
 
 /**
@@ -20,7 +19,7 @@ data class Table(
 /**
  * An error logged when there is an attempt to redefine an already defined symbol in the code that is being compiled.
  */
-class SymbolRedefinitionError(ctx: SourceContext, val ident: String) : ErrorFromContext(ctx, "\"$ident\" is already defined")
+class SymbolRedefinitionError(ctx: SourceContext, val ident: String) : CompileError(ctx, "\"$ident\" is already defined")
 
 /**
  * List of language keywords that can't be used as identifiers
@@ -58,7 +57,7 @@ class SymbolTable {
         val table = scopeStack.peek()
 
         if (RESERVED_WORDS.contains(ident) || table.symbols.containsKey(ident)) {
-            ErrorLogger.registerError(SymbolRedefinitionError(node.ctx, ident))
+            ErrorLogger += SymbolRedefinitionError(node.ctx, ident)
         } else {
             table.symbols[ident] = node
         }
@@ -138,7 +137,7 @@ class CreatingSymbolTableSession(symbolTable: Table) {
         val table = scopeStack.peek()
 
         if (RESERVED_WORDS.contains(ident) || table.symbols.containsKey(ident)) {
-            ErrorLogger.registerError(SymbolRedefinitionError(node.ctx, ident))
+            ErrorLogger += SymbolRedefinitionError(node.ctx, ident)
         }
 
         table.symbols[ident] = node

--- a/compiler/src/main/kotlin/errorhandling.kt
+++ b/compiler/src/main/kotlin/errorhandling.kt
@@ -1,50 +1,33 @@
 package dk.aau.cs.d409f19.cellumata
 
 import dk.aau.cs.d409f19.cellumata.ast.SourceContext
-import org.antlr.v4.runtime.ParserRuleContext
-import java.nio.file.Files
-import java.nio.file.Path
+import java.io.PrintStream
+import java.util.stream.Stream
 
 /**
- * Interface for all compiler errors that does not terminate a compiler phase.
+ * A Loggable can be logged in the ErrorLogger.
+ * @param description the description of the logged thing
+ * @param ctx the source context from which this was created. Use EMPTY_CONTEXT if there's not source
  * @see ErrorLogger
  */
-abstract class CompileError(msg: String) : java.lang.RuntimeException(msg) {
-
-    /**
-     * The description of the error in plain text
-     */
-    abstract fun description(): String
-
-    /**
-     * The line number on which the first character that produced this error, line=1..n
-     */
-    abstract fun getLineNumber(): Int
-
-    /**
-     * The index of the first character of this error relative to the
-     * beginning of the line at which it occurs, 0..n-1
-     */
-    abstract fun getCharPositionInLine(): Int
-}
+abstract class Loggable(
+    val ctx: SourceContext?,
+    val description: String
+) : java.lang.RuntimeException(description)
 
 /**
- * A compiler error based on the context from the source program.
+ * A compiler error. All errors originates from some context from the source program. Errors stops the compilation
+ * after the current phase is complete.
+ * @see ErrorLogger
  */
-open class ErrorFromContext(val ctx: SourceContext, private val description: String) : CompileError(description) {
+open class CompileError(ctx: SourceContext?, description: String) : Loggable(ctx, description)
 
-    override fun description(): String {
-        return description
-    }
-
-    override fun getLineNumber(): Int {
-        return ctx.lineNumber
-    }
-
-    override fun getCharPositionInLine(): Int {
-        return ctx.charPositionInLine
-    }
-}
+/**
+ * A compiler warning. All warnings originates from some context from the source program. Warnings does not
+ * stop the compilation.
+ * @see ErrorLogger
+ */
+open class CompileWarning(ctx: SourceContext?, description: String) : Loggable(ctx, description)
 
 /**
  * The ErrorLogger holds all compile errors so far.
@@ -52,13 +35,21 @@ open class ErrorFromContext(val ctx: SourceContext, private val description: Str
 object ErrorLogger {
 
     private val errors: MutableList<CompileError> = mutableListOf()
+    private val warnings: MutableList<CompileWarning> = mutableListOf()
 
-    fun registerError(err: CompileError) {
-        errors += err
+    operator fun plusAssign(error: CompileError) = log(error)
+    operator fun plusAssign(warning: CompileWarning) = log(warning)
+
+    fun log(error: CompileError) {
+        errors += error
+    }
+
+    fun log(warning: CompileWarning) {
+        warnings += warning
     }
 
     /**
-     * Assert that there is no errors. Throws a TerminatedCompilationException if there is any errors.
+     * Assert that there are no errors. Throws a TerminatedCompilationException if there are any errors.
      */
     fun assertNoErrors() {
         if (hasErrors()) {
@@ -66,17 +57,50 @@ object ErrorLogger {
         }
     }
 
-    fun hasErrors(): Boolean {
-        return errors.size > 0
+    fun hasErrors(): Boolean = errors.size > 0
+
+    fun hasWarnings(): Boolean = warnings.size > 0
+
+    /**
+     * Prints all errors in a nicely formatted way. If a stream of source code lines is provided, the printing will be
+     * verbose where the exact position of the error's source context will be displayed.
+     */
+    fun printAllErrors(lines: Stream<String>? = null) {
+        if (hasErrors()) {
+            if (lines == null) {
+                printAll("Error", errors, System.err)
+            } else {
+                printAllVerbosely("Error", errors, lines, System.err)
+            }
+        }
     }
 
     /**
-     * Prints all errors in a nicely formatted way.
+     * Prints all warnings in a nicely formatted way. If a stream of source code lines is provided, the printing will be
+     * verbose where the exact position of the warnings's source context will be displayed.
      */
-    fun printAllErrors(path: Path) {
+    fun printAllWarnings(lines: Stream<String>? = null) {
+        if (hasWarnings()) {
+            if (lines == null) {
+                printAll("Warning", warnings, System.out)
+            } else {
+                printAllVerbosely("Warning", warnings, lines, System.out)
+            }
+        }
+    }
 
-        val lines = Files.lines(path)
-        val sortedErrors = errors.sortedWith(compareBy<CompileError> { it.getLineNumber() }.thenBy { it.getCharPositionInLine() })
+    /**
+     * Prints all the provided loggables in a nicely formatted way. The printing will be verbose where the exact
+     * position of the loggable's source context will be displayed.
+     * @see printAll
+     */
+    private fun printAllVerbosely(type: String, loggables: List<Loggable>, lines: Stream<String>, printStream: PrintStream) {
+
+        val sortedErrors = loggables.sortedWith(compareBy<Loggable> {
+            if (it.ctx == null) 0 else it.ctx.lineNumber
+        }.thenBy {
+            if (it.ctx == null) 0 else it.ctx.charPositionInLine
+        })
 
         // Line index initialised to 1, as lines are not zero-indexed
         var currentLineIndex = 1
@@ -86,12 +110,17 @@ object ErrorLogger {
         for (line in lines) {
             var error = sortedErrors[currentErrorIndex]
 
-            while (error.getLineNumber() == currentLineIndex) {
+            while (error.ctx == null || error.ctx!!.lineNumber == currentLineIndex) {
 
                 // Print the error
-                System.err.println("Error at (${error.getLineNumber()}, ${error.getCharPositionInLine()}): ${error.description()}")
-                System.err.println(line) // print the line
-                System.err.println(errorPointerString(error.getCharPositionInLine()))
+                if (error.ctx == null) {
+                    printStream.println("$type: ${error.description}")
+                } else {
+                    printStream.println("$type at ${error.ctx}: ${error.description}")
+                    // print the source line and a pointer to the context location
+                    printStream.println(line)
+                    printStream.println(errorPointerString(error.ctx!!.charPositionInLine))
+                }
 
                 // Check next error. It might be on the same line
                 currentErrorIndex++
@@ -106,21 +135,33 @@ object ErrorLogger {
         }
     }
 
-    fun printAllErrors() {
-        val sortedErrors = errors.sortedWith(compareBy<CompileError> { it.getLineNumber() }.thenBy { it.getCharPositionInLine() })
+    /**
+     * Prints all the provided loggables to the print stream. This will not be verbose.
+     * @see printAllVerbosely
+     */
+    private fun printAll(type: String, loggables: List<Loggable>, printStream: PrintStream) {
+        val sortedErrors = loggables.sortedWith(compareBy<Loggable> {
+            if (it.ctx == null) 0 else it.ctx.lineNumber
+        }.thenBy {
+            if (it.ctx == null) 0 else it.ctx.charPositionInLine
+        })
 
-        sortedErrors.forEach() {
-            System.err.println("Error at (${it.getLineNumber()}, ${it.getCharPositionInLine()}): ${it.description()}")
+        sortedErrors.forEach {
+            if (it.ctx == null) {
+                printStream.println("$type: ${it.description}")
+            } else {
+                printStream.println("$type at ${it.ctx}: ${it.description}")
+            }
         }
-
     }
 
-    fun allErrors(): List<CompileError> {
-        return errors
-    }
+    fun allErrors(): List<CompileError> = errors
+
+    fun allWarnings(): List<CompileWarning> = warnings
 
     fun reset() {
         errors.clear()
+        warnings.clear()
     }
 
     /**

--- a/compiler/src/main/kotlin/visitors/prettyprinter.kt
+++ b/compiler/src/main/kotlin/visitors/prettyprinter.kt
@@ -12,7 +12,8 @@ class PrettyPrinter : BaseASTVisitor() {
     /**
      * Print accumulated program from string builder
      */
-    fun print() {
+    fun print(ast: AST) {
+        visit(ast)
         println(stringBuilder.toString())
     }
 

--- a/compiler/src/main/kotlin/visitors/sanitychecker.kt
+++ b/compiler/src/main/kotlin/visitors/sanitychecker.kt
@@ -1,19 +1,20 @@
 package dk.aau.cs.d409f19.cellumata.visitors
 
 
-import dk.aau.cs.d409f19.cellumata.ErrorFromContext
+import dk.aau.cs.d409f19.cellumata.CompileError
+import dk.aau.cs.d409f19.cellumata.CompileWarning
 import dk.aau.cs.d409f19.cellumata.ErrorLogger
 import dk.aau.cs.d409f19.cellumata.ast.*
 
 /**
  * The error thrown when a become, continue, break or return statement is in a place where it should not be
  */
-class SanityError(ctx: SourceContext, description: String) : ErrorFromContext(ctx, description)
+class SanityError(ctx: SourceContext, description: String) : CompileError(ctx, description)
 
 /**
  * The error for incorrect number of dimensions for coordinates
  */
-class DimensionsError(ctx: SourceContext, description: String) : ErrorFromContext(ctx, description)
+class DimensionsError(ctx: SourceContext, description: String) : CompileError(ctx, description)
 
 /**
  * A class to check that a become, return, break and continue statement does not appear in a place it should not be
@@ -36,7 +37,7 @@ class SanityChecker : BaseASTVisitor() {
 
     override fun visit(node: Coordinate) {
         if (dimensions != node.axes.size) {
-            ErrorLogger.registerError(DimensionsError(node.ctx, "Coordinate does not match the number of dimensions declared in the world-declaration."))
+            ErrorLogger += DimensionsError(node.ctx, "Coordinate does not match the number of dimensions declared in the world-declaration.")
         }
         super.visit(node)
     }
@@ -45,7 +46,7 @@ class SanityChecker : BaseASTVisitor() {
     override fun visit(node: BecomeStmt) {
         super.visit(node)
         if (inAFunction)
-            ErrorLogger.registerError(SanityError(node.ctx, "Become statements cannot be in functions"))
+            ErrorLogger += SanityError(node.ctx, "Become statements cannot be in functions")
     }
 
     var inAState = false
@@ -63,14 +64,14 @@ class SanityChecker : BaseASTVisitor() {
     override fun visit(node: ReturnStmt) {
         super.visit(node)
         if (inAState)
-            ErrorLogger.registerError(SanityError(node.ctx, "Return statements cannot be in states"))
+            ErrorLogger += SanityError(node.ctx, "Return statements cannot be in states")
     }
 
     // Throws an error if a # is found outside a state
     override fun visit(node: StateIndexExpr) {
         super.visit(node)
         if (!inAState)
-            ErrorLogger.registerError(SanityError(node.ctx, "# is only allowed in states"))
+            ErrorLogger += SanityError(node.ctx, "# is only allowed in states")
     }
 
     var inALoop = false
@@ -85,14 +86,14 @@ class SanityChecker : BaseASTVisitor() {
     override fun visit(node: BreakStmt) {
         super.visit(node)
         if (!inALoop)
-            ErrorLogger.registerError(SanityError(node.ctx, "Break statements are only allowed in loops"))
+            ErrorLogger += SanityError(node.ctx, "Break statements are only allowed in loops")
     }
 
     // Throws an error if a continue is found outside a loop
     override fun visit(node: ContinueStmt) {
         super.visit(node)
         if (!inALoop)
-            ErrorLogger.registerError(SanityError(node.ctx, "Continue statements are only allowed in loops"))
+            ErrorLogger += SanityError(node.ctx, "Continue statements are only allowed in loops")
     }
 
     // Checks if there are 0 or 1 state,
@@ -102,8 +103,8 @@ class SanityChecker : BaseASTVisitor() {
         super.visit(node)
 
         if (numberOfStates == 0)
-            ErrorLogger.registerError(SanityError(node.ctx, "A state is needed"))
+            ErrorLogger += SanityError(node.ctx, "A state is needed")
         else if (numberOfStates == 1)
-            System.err.println("Warning: There is only one state")
+            ErrorLogger += CompileWarning(null, "There is only one state")
     }
 }

--- a/compiler/src/main/kotlin/visitors/symbolchecker.kt
+++ b/compiler/src/main/kotlin/visitors/symbolchecker.kt
@@ -1,14 +1,13 @@
 package dk.aau.cs.d409f19.cellumata.visitors
 
-import dk.aau.cs.d409f19.cellumata.ErrorFromContext
+import dk.aau.cs.d409f19.cellumata.CompileError
 import dk.aau.cs.d409f19.cellumata.ErrorLogger
 import dk.aau.cs.d409f19.cellumata.ast.*
-import org.antlr.v4.runtime.ParserRuleContext
 
 /**
  * Logged when a undefined symbol is encountered. This exception indicates there is a use-before-declaration scenario.
  */
-class UndeclaredNameException(ctx: SourceContext, val ident: String) : ErrorFromContext(ctx, "\"$ident\" is undeclared.")
+class UndeclaredNameException(ctx: SourceContext, val ident: String) : CompileError(ctx, "\"$ident\" is undeclared.")
 
 /**
  * Walks through the abstract syntax tree, extracts symbols, and checks for use-before-declaration.
@@ -41,7 +40,7 @@ class ScopeCheckVisitor(symbolTable: Table = Table()) : BaseASTVisitor() {
         // Check if the name is in the symbol table
         val symb = symbolTableSession.getSymbol(node.spelling)
         if (symb == null) {
-            ErrorLogger.registerError(UndeclaredNameException(node.ctx, node.spelling))
+            ErrorLogger += UndeclaredNameException(node.ctx, node.spelling)
         }
         super.visit(node)
     }
@@ -73,7 +72,7 @@ class ScopeCheckVisitor(symbolTable: Table = Table()) : BaseASTVisitor() {
             // assignment
             val symb = symbolTableSession.getSymbol(node.ident)
             if (symb == null) {
-                ErrorLogger.registerError(UndeclaredNameException(node.ctx, node.ident))
+                ErrorLogger += UndeclaredNameException(node.ctx, node.ident)
             }
         }
 
@@ -88,7 +87,7 @@ class ScopeCheckVisitor(symbolTable: Table = Table()) : BaseASTVisitor() {
 
     override fun visit(node: FuncCallExpr) {
         if (symbolTableSession.getSymbol(node.ident) == null) {
-            ErrorLogger.registerError(UndeclaredNameException(node.ctx, node.ident))
+            ErrorLogger += UndeclaredNameException(node.ctx, node.ident)
         }
         super.visit(node)
     }

--- a/compiler/src/main/kotlin/visitors/typechecker.kt
+++ b/compiler/src/main/kotlin/visitors/typechecker.kt
@@ -1,6 +1,6 @@
 package dk.aau.cs.d409f19.cellumata.visitors
 
-import dk.aau.cs.d409f19.cellumata.ErrorFromContext
+import dk.aau.cs.d409f19.cellumata.CompileError
 import dk.aau.cs.d409f19.cellumata.ErrorLogger
 import dk.aau.cs.d409f19.cellumata.ast.*
 import kotlin.AssertionError
@@ -8,7 +8,7 @@ import kotlin.AssertionError
 /**
  * Error for violation of the type rules
  */
-class TypeError(ctx: SourceContext, description: String) : ErrorFromContext(ctx, description)
+class TypeError(ctx: SourceContext, description: String) : CompileError(ctx, description)
 
 /**
  * Synthesizes types by moving them up the abstract syntax tree according to the type rules, and check that there is no violation of the type rules
@@ -20,10 +20,10 @@ class TypeChecker(symbolTable: Table) : ScopedASTVisitor(symbolTable = symbolTab
         super.visit(node)
 
         if (node.left.getType() != BooleanType) {
-            ErrorLogger.registerError(TypeError(node.left.ctx, "Expected boolean expression in left hand side of or-expression."))
+            ErrorLogger += TypeError(node.left.ctx, "Expected boolean expression in left hand side of or-expression.")
         }
         if (node.right.getType() != BooleanType) {
-            ErrorLogger.registerError(TypeError(node.right.ctx, "Expected boolean expression in right hand side of or-expression."))
+            ErrorLogger += TypeError(node.right.ctx, "Expected boolean expression in right hand side of or-expression.")
         }
 
         node.setType(BooleanType)
@@ -33,10 +33,10 @@ class TypeChecker(symbolTable: Table) : ScopedASTVisitor(symbolTable = symbolTab
         super.visit(node)
 
         if (node.left.getType() != BooleanType) {
-            ErrorLogger.registerError(TypeError(node.left.ctx, "Expected boolean expression in left hand side of and-expression."))
+            ErrorLogger += TypeError(node.left.ctx, "Expected boolean expression in left hand side of and-expression.")
         }
         if (node.right.getType() != BooleanType) {
-            ErrorLogger.registerError(TypeError(node.right.ctx, "Expected boolean expression in right hand side of and-expression."))
+            ErrorLogger += TypeError(node.right.ctx, "Expected boolean expression in right hand side of and-expression.")
         }
 
         node.setType(BooleanType)
@@ -57,7 +57,7 @@ class TypeChecker(symbolTable: Table) : ScopedASTVisitor(symbolTable = symbolTab
             node.left.getType() is ArrayType && (node.left.getType() as ArrayType).subtype == StateType && node.right.getType() == LocalNeighbourhoodType -> BooleanType
             node.left.getType() is ArrayType && node.right.getType() is ArrayType -> BooleanType
             else -> {
-                ErrorLogger.registerError(TypeError(node.ctx, "Could not compare the types of right and left hand side of inequality-expression."))
+                ErrorLogger += TypeError(node.ctx, "Could not compare the types of right and left hand side of inequality-expression.")
                 null
             }
         })
@@ -78,7 +78,7 @@ class TypeChecker(symbolTable: Table) : ScopedASTVisitor(symbolTable = symbolTab
             node.left.getType() is ArrayType && (node.left.getType() as ArrayType).subtype == StateType && node.right.getType() == LocalNeighbourhoodType -> BooleanType
             node.left.getType() is ArrayType && node.right.getType() is ArrayType -> BooleanType
             else -> {
-                ErrorLogger.registerError(TypeError(node.ctx, "Could not compare the types of right and left hand side of equality-expression."))
+                ErrorLogger += TypeError(node.ctx, "Could not compare the types of right and left hand side of equality-expression.")
                 null
             }
         })
@@ -93,7 +93,7 @@ class TypeChecker(symbolTable: Table) : ScopedASTVisitor(symbolTable = symbolTab
             node.left.getType() == IntegerType && node.right.getType() == FloatType -> BooleanType
             node.left.getType() == FloatType && node.right.getType() == IntegerType -> BooleanType
             else -> {
-                ErrorLogger.registerError(TypeError(node.ctx, "Right and left hand side of must be either float or integer."))
+                ErrorLogger += TypeError(node.ctx, "Right and left hand side of must be either float or integer.")
                 null
             }
         })
@@ -108,7 +108,7 @@ class TypeChecker(symbolTable: Table) : ScopedASTVisitor(symbolTable = symbolTab
             node.left.getType() == IntegerType && node.right.getType() == FloatType -> BooleanType
             node.left.getType() == FloatType && node.right.getType() == IntegerType -> BooleanType
             else -> {
-                ErrorLogger.registerError(TypeError(node.ctx, "Right and left hand side of must be either float or integer."))
+                ErrorLogger += TypeError(node.ctx, "Right and left hand side of must be either float or integer.")
                 null
             }
         })
@@ -123,7 +123,7 @@ class TypeChecker(symbolTable: Table) : ScopedASTVisitor(symbolTable = symbolTab
             node.left.getType() == IntegerType && node.right.getType() == FloatType -> BooleanType
             node.left.getType() == FloatType && node.right.getType() == IntegerType -> BooleanType
             else -> {
-                ErrorLogger.registerError(TypeError(node.ctx, "Right and left hand side of must be either float or integer."))
+                ErrorLogger += TypeError(node.ctx, "Right and left hand side of must be either float or integer.")
                 null
             }
         })
@@ -138,7 +138,7 @@ class TypeChecker(symbolTable: Table) : ScopedASTVisitor(symbolTable = symbolTab
             node.left.getType() == IntegerType && node.right.getType() == FloatType -> BooleanType
             node.left.getType() == FloatType && node.right.getType() == IntegerType -> BooleanType
             else -> {
-                ErrorLogger.registerError(TypeError(node.ctx, "Right and left hand side of must be either float or integer."))
+                ErrorLogger += TypeError(node.ctx, "Right and left hand side of must be either float or integer.")
                 null
             }
         })
@@ -153,7 +153,7 @@ class TypeChecker(symbolTable: Table) : ScopedASTVisitor(symbolTable = symbolTab
             node.left.getType() == IntegerType && node.right.getType() == FloatType -> FloatType
             node.left.getType() == FloatType && node.right.getType() == IntegerType -> FloatType
             else -> {
-                ErrorLogger.registerError(TypeError(node.ctx, "Right and left hand side of must be either float or integer."))
+                ErrorLogger += TypeError(node.ctx, "Right and left hand side of must be either float or integer.")
                 null
             }
         })
@@ -168,7 +168,7 @@ class TypeChecker(symbolTable: Table) : ScopedASTVisitor(symbolTable = symbolTab
             node.left.getType() == IntegerType && node.right.getType() == FloatType -> FloatType
             node.left.getType() == FloatType && node.right.getType() == IntegerType -> FloatType
             else -> {
-                ErrorLogger.registerError(TypeError(node.ctx, "Right and left hand side of must be either float or integer."))
+                ErrorLogger += TypeError(node.ctx, "Right and left hand side of must be either float or integer.")
                 null
             }
         })
@@ -183,7 +183,7 @@ class TypeChecker(symbolTable: Table) : ScopedASTVisitor(symbolTable = symbolTab
             node.left.getType() == IntegerType && node.right.getType() == FloatType -> FloatType
             node.left.getType() == FloatType && node.right.getType() == IntegerType -> FloatType
             else -> {
-                ErrorLogger.registerError(TypeError(node.ctx, "Right and left hand side of must be either float or integer."))
+                ErrorLogger += TypeError(node.ctx, "Right and left hand side of must be either float or integer.")
                 null
             }
         })
@@ -198,7 +198,7 @@ class TypeChecker(symbolTable: Table) : ScopedASTVisitor(symbolTable = symbolTab
             node.left.getType() == IntegerType && node.right.getType() == FloatType -> FloatType
             node.left.getType() == FloatType && node.right.getType() == IntegerType -> FloatType
             else -> {
-                ErrorLogger.registerError(TypeError(node.ctx, "Right and left hand side of must be either float or integer."))
+                ErrorLogger += TypeError(node.ctx, "Right and left hand side of must be either float or integer.")
                 null
             }
         })
@@ -211,7 +211,7 @@ class TypeChecker(symbolTable: Table) : ScopedASTVisitor(symbolTable = symbolTab
             IntegerType -> IntegerType
             FloatType -> FloatType
             else -> {
-                ErrorLogger.registerError(TypeError(node.ctx, "Only float or integer can be negative."))
+                ErrorLogger += TypeError(node.ctx, "Only float or integer can be negative.")
                 null
             }
         })
@@ -221,7 +221,7 @@ class TypeChecker(symbolTable: Table) : ScopedASTVisitor(symbolTable = symbolTab
         super.visit(node)
 
         if (node.value.getType() != BooleanType) {
-            ErrorLogger.registerError(TypeError(node.ctx, "Can only invert boolean expressions."))
+            ErrorLogger += TypeError(node.ctx, "Can only invert boolean expressions.")
         }
 
         node.setType(BooleanType)
@@ -289,7 +289,7 @@ class TypeChecker(symbolTable: Table) : ScopedASTVisitor(symbolTable = symbolTab
             val types = node.body.values.map { it.getType() }.toList()
             if (types.distinct().count() > 1) {
                 // ToDo int to float conversion
-                ErrorLogger.registerError(TypeError(node.ctx, "Cannot determine type of array because it is initialised with multiple types."))
+                ErrorLogger += TypeError(node.ctx, "Cannot determine type of array because it is initialised with multiple types.")
                 node.setType(null)
                 return
             }
@@ -317,7 +317,7 @@ class TypeChecker(symbolTable: Table) : ScopedASTVisitor(symbolTable = symbolTab
         // ToDo implicit conversion, declaredType == float, and valuesType == integer -> type = float
         node.setType(if (node.body.values.isNotEmpty()) {
                 if (node.declaredType is ArrayType && !compareType(node.declaredType.subtype, valuesType)) {
-                    ErrorLogger.registerError(TypeError(node.ctx, "Cannot determine type of array since initialised values does not match the declared type."))
+                    ErrorLogger += TypeError(node.ctx, "Cannot determine type of array since initialised values does not match the declared type.")
                     node.setType(null)
                     return
                 }
@@ -379,7 +379,7 @@ class TypeChecker(symbolTable: Table) : ScopedASTVisitor(symbolTable = symbolTab
             node.left.getType() == IntegerType && node.right.getType() == FloatType -> FloatType
             node.left.getType() == FloatType && node.right.getType() == IntegerType -> FloatType
             else -> {
-                ErrorLogger.registerError(TypeError(node.ctx, "Right and left hand side of must be either float or integer."))
+                ErrorLogger += TypeError(node.ctx, "Right and left hand side of must be either float or integer.")
                 null
             }
         })
@@ -392,7 +392,7 @@ class TypeChecker(symbolTable: Table) : ScopedASTVisitor(symbolTable = symbolTab
             node.value.setType(when {
                 node.value.getType() == IntegerType -> FloatType
                 else -> {
-                    ErrorLogger.registerError(TypeError(node.ctx, "Wrong return type (${node.value.getType()}). Expected $expectedReturn"))
+                    ErrorLogger += TypeError(node.ctx, "Wrong return type (${node.value.getType()}). Expected $expectedReturn")
                     null
                     }
                 }

--- a/compiler/src/test/kotlin/utility.kt
+++ b/compiler/src/test/kotlin/utility.kt
@@ -3,9 +3,10 @@ package dk.aau.cs.d409f19
 import dk.aau.cs.d409f19.antlr.CellmataLexer
 import dk.aau.cs.d409f19.antlr.CellmataParser
 import dk.aau.cs.d409f19.cellumata.CompilerData
+import dk.aau.cs.d409f19.cellumata.CompilerSettings
 import dk.aau.cs.d409f19.cellumata.ErrorLogger
 import dk.aau.cs.d409f19.cellumata.ast.reduce
-import dk.aau.cs.d409f19.cellumata.compileSource
+import dk.aau.cs.d409f19.cellumata.compile
 import dk.aau.cs.d409f19.cellumata.visitors.SanityChecker
 import dk.aau.cs.d409f19.cellumata.visitors.ScopeCheckVisitor
 import dk.aau.cs.d409f19.cellumata.visitors.TypeChecker
@@ -15,8 +16,8 @@ import org.antlr.v4.runtime.CommonTokenStream
 /**
  * Compile a Cellmata program given as string parameter
  */
-fun compileTestProgram(program: String): CompilerData {
-    return compileSource(program)
+fun compileTestProgram(program: String, settings: CompilerSettings = CompilerSettings()): CompilerData {
+    return compile(CharStreams.fromString(program), settings)
 }
 
 /**


### PR DESCRIPTION
This PR refractors the ErrorLogger and adds warnings. The ErrorLogger is now also able to print errors with different levels of verbosity:
* standard verbosity is simply "Error at (32: 5): Some error messages" for both errors and warnings
* verbose (arg: -v) will make errors print their exact location in source context
* very verbose (arg: -vv) will make both errors and warnings print their exact location in source context

If an error or warning doesn't have a source context (ctx = null) the "at (l:c)" part is not printed.

Depends on #111