### PR TITLE
Add negative floats-tests to AST-tests

### DIFF
--- a/compiler/src/test/kotlin/asttest.kt
+++ b/compiler/src/test/kotlin/asttest.kt
@@ -237,7 +237,6 @@ class ASTTest {
 
         /**
          * Test constant declaration float values. Assumes that default world declaration passes.
-         * TODO: Does not include negative values as they fail! When fixed, they should be implemented again.
          */
         @ParameterizedTest
         @ValueSource(strings = ["3.14159", "1000.99", "123456.789", "-42.0000123401234", "-42.00001234012340"])

--- a/compiler/src/test/kotlin/asttest.kt
+++ b/compiler/src/test/kotlin/asttest.kt
@@ -240,7 +240,7 @@ class ASTTest {
          * TODO: Does not include negative values as they fail! When fixed, they should be implemented again.
          */
         @ParameterizedTest
-        @ValueSource(strings = ["3.14159", "1000.99", "123456.789"])
+        @ValueSource(strings = ["3.14159", "1000.99", "123456.789", "-42.0000123401234", "-42.00001234012340"])
         fun constDeclFloatTest(value: String) {
             // Get AST for boilerplate program with only world declaration and constant declaration
             val compilerData = compileTestProgramInsecure(getWorldDeclString() + "\n\n" + getConstDeclString(value = value))

--- a/compiler/src/test/kotlin/symboltest.kt
+++ b/compiler/src/test/kotlin/symboltest.kt
@@ -31,7 +31,7 @@ class SymbolTest {
      */
     fun assignStmtPassData(): List<String> {
         return IntRange(-50, 50).step(10).map { it.toString() }
-            .union(listOf("true", "false", "113240987.734723984", "1.0000000000000001"))
+            .union(listOf("true", "false", "113240987.734723984", "1.0000000000000001", "-1.0000000000000001"))
             .toList()
     }
 
@@ -97,7 +97,9 @@ class SymbolTest {
             Arguments.of("x", listOf("true", "true")),
             Arguments.of("x", listOf("4.2", "42.2")),
             Arguments.of("x", listOf("4", "2+2")),
-            Arguments.of("x", listOf("true", "5"))
+            Arguments.of("x", listOf("true", "5")),
+            Arguments.of("x", listOf("false", "-42.5")),
+            Arguments.of("x", listOf("-42.5", "42.5"))
         )
     }
 


### PR DESCRIPTION
Since negative float literals are now correctly represented, negative float literals has been added to AST-tests.

Resolves #84 