### PR TITLE
Add git information to compiler jar

### DIFF
--- a/compiler/build.gradle
+++ b/compiler/build.gradle
@@ -32,13 +32,21 @@ task run(type: JavaExec) {
 }
 
 import org.ajoberstar.grgit.*
-def repo = Grgit.open(buildscript.sourceFile.parent + "/..")
 
 jar {
     manifest {
+        def repo = Grgit.open(buildscript.sourceFile.parent + "/..")
+        def repoStatus = repo.status()
+        def filesChanged = repoStatus.unstaged.added.size() +
+                repoStatus.unstaged.modified.size() +
+                repoStatus.unstaged.removed.size() +
+                repoStatus.staged.added.size() +
+                repoStatus.staged.modified.size() +
+                repoStatus.staged.removed.size()
         attributes 'Main-Class': 'dk.aau.cs.d409f19.cellumata.MainKt',
             'Git-Commit': repo.head().id,
             'Git-Branch': repo.branch.getCurrent().getName(),
+            'Git-Dirty': filesChanged != 0,
             'Build-Time': new Date().format("yyyy-MM-dd'T'HH:mm:ssZ")
     }
 

--- a/compiler/build.gradle
+++ b/compiler/build.gradle
@@ -1,7 +1,18 @@
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'org.ajoberstar:gradle-git:1.7.2'
+    }
+}
+
 plugins {
     id 'org.jetbrains.kotlin.jvm' version '1.3.11'
     id 'antlr'
 }
+
+apply plugin: 'org.ajoberstar.grgit'
 
 group 'dk.aau.cs.d409f19'
 version '1.0-SNAPSHOT'
@@ -20,9 +31,15 @@ task run(type: JavaExec) {
     }
 }
 
+import org.ajoberstar.grgit.*
+def repo = Grgit.open(buildscript.sourceFile.parent + "/..")
+
 jar {
     manifest {
-        attributes 'Main-Class': 'dk.aau.cs.d409f19.cellumata.MainKt'
+        attributes 'Main-Class': 'dk.aau.cs.d409f19.cellumata.MainKt',
+            'Git-Commit': repo.head().id,
+            'Git-Branch': repo.branch.getCurrent().getName(),
+            'Build-Time': new Date().format("yyyy-MM-dd'T'HH:mm:ssZ")
     }
 
     // This line of code recursively collects and copies all of a project's files


### PR DESCRIPTION
These changes adds git status information, including last commit, current branch, whether the working tree is dirty, and the time of build, to the jar manifest. This makes the any distributed compiler version traceable, and there for easier to debug.