### PR TITLE
Added info about multi-states. Adjusted printers accordingly.

### DIFF
--- a/compiler/src/main/antlr/Cellmata.g4
+++ b/compiler/src/main/antlr/Cellmata.g4
@@ -23,7 +23,7 @@ world_cellsize : WORLD_CELLSIZE ASSIGN value=integer_literal END ;
 world_edge : WORLD_EDGE ASSIGN state=IDENT END ;
 
 // State
-state_decl : STMT_STATE state_ident (SQ_BRACKET_START integer_literal SQ_BRACKET_END)? state_rgb code_block ;
+state_decl : STMT_STATE state_ident (SQ_BRACKET_START multiStateCount=integer_literal SQ_BRACKET_END)? state_rgb code_block ;
 state_ident : IDENT ;
 state_rgb : PAREN_START red=integer_literal LIST_SEP green=integer_literal LIST_SEP blue=integer_literal PAREN_END ;
 

--- a/compiler/src/main/kotlin/ast/ast.kt
+++ b/compiler/src/main/kotlin/ast/ast.kt
@@ -321,6 +321,7 @@ class ConstDecl(
 class StateDecl(
     ctx: SourceContext,
     var ident: String,
+    val multiStateCount: Int,
     var red: Short,
     var blue: Short,
     var green: Short,

--- a/compiler/src/main/kotlin/ast/reduce.kt
+++ b/compiler/src/main/kotlin/ast/reduce.kt
@@ -233,6 +233,7 @@ private fun reduceDecl(node: ParseTree): Decl {
         is CellmataParser.State_declContext -> StateDecl(
             ctx = SourceContext(node),
             ident = node.state_ident().text,
+            multiStateCount = node.multiStateCount?.text?.toInt() ?: 1,
             red = parseColor(node.state_rgb().red),
             green = parseColor(node.state_rgb().green),
             blue = parseColor(node.state_rgb().blue),

--- a/compiler/src/main/kotlin/visitors/grapher.kt
+++ b/compiler/src/main/kotlin/visitors/grapher.kt
@@ -65,7 +65,11 @@ class ASTGrapher(sink: OutputStream, private val output: PrintStream = PrintStre
     }
 
     override fun visit(node: StateDecl) {
-        printLabel(node, "State\\n" + node.ident + "\\nred=" + node.red + "\\ngreen=" + node.green + "\\nblue=" + node.blue)
+        printLabel(node, "State\\n${node.ident}\\n" +
+                "count=${node.multiStateCount}" +
+                "red=${node.red}\\n" +
+                "green=${node.green}\\n" +
+                "blue=${node.blue}\\n")
         printNode(node, node.body)
         depth++
         super.visit(node)

--- a/compiler/src/main/kotlin/visitors/prettyprinter.kt
+++ b/compiler/src/main/kotlin/visitors/prettyprinter.kt
@@ -109,7 +109,7 @@ class PrettyPrinter : BaseASTVisitor() {
      */
     override fun visit(node: StateDecl) {
         // Print signature of state. TODO: must take multi-state-declaration into account when implemented
-        stringBuilder.appendln("state ${node.ident} (${node.red}, ${node.green}, ${node.blue}) {")
+        stringBuilder.appendln("state ${node.ident}[${node.multiStateCount}] (${node.red}, ${node.green}, ${node.blue}) {")
 
         // Print body
         visit(node.body)

--- a/compiler/src/main/kotlin/visitors/sanitychecker.kt
+++ b/compiler/src/main/kotlin/visitors/sanitychecker.kt
@@ -92,8 +92,9 @@ class SanityChecker : BaseASTVisitor() {
     override fun visit(node: StateDecl) {
         inAState = true
         super.visit(node)
-        // counts the number of times a state node is visited
-        numberOfStates += 1 // TODO Should count more if there is multi-states
+        // counts the number of states
+        if (node.multiStateCount > 0) numberOfStates += node.multiStateCount
+        else ErrorLogger += SanityError(node.ctx, "Multi-states must declare at least 1 state.")
         inAState = false
     }
 

--- a/compiler/src/main/resources/compiling-programs/large-program.cell
+++ b/compiler/src/main/resources/compiling-programs/large-program.cell
@@ -51,10 +51,10 @@ state alive5 (0, 0, 0) {
             continue;
         }
     }
-    become alive6;
+    become alive4;
 }
 
-state alive6 (0, 0, 0) {
+state dead[4] (0, 0, 0) {
     let a = -foo(42);
     let b = bar(a, true);
 


### PR DESCRIPTION
This adds information about how many states a multi-state-decl declares. The sanity checker makes sure that it is not 0 or negative. Pretty printer and grapher have been adjusted accordingly.

It is still not possible to lookup multi-state, e.g. `Alive[2]`.

Resolves #150 