### PR TITLE
Codegen multistate

### DIFF
--- a/compiler/runtime/src/main/kotlin/runtime/builtins.kt
+++ b/compiler/runtime/src/main/kotlin/runtime/builtins.kt
@@ -2,38 +2,38 @@ package dk.aau.cs.d409f18.cellumata.codegen.kotlin.runtime
 
 import kotlin.random.Random
 
-fun `builtin count`(state: Int, nei: List<Int>): Int {
+fun `builtin count`(worldView: IWorldView, state: Int, nei: List<Int>): Int {
     return nei.count { it == state }
 }
 
-fun `builtin randi`(min: Int, max: Int): Int {
+fun `builtin randi`(worldView: IWorldView, min: Int, max: Int): Int {
     return Random.nextInt(min, max)
 }
 
-fun `builtin randf`(min: Float, max: Float): Float {
+fun `builtin randf`(worldView: IWorldView, min: Float, max: Float): Float {
     return Random.nextFloat() * (max - min) + min
 }
 
-fun `builtin absi`(value: Int): Int {
+fun `builtin absi`(worldView: IWorldView, value: Int): Int {
     return Math.abs(value)
 }
 
-fun `builtin absf`(value: Float): Float {
+fun `builtin absf`(worldView: IWorldView, value: Float): Float {
     return Math.abs(value)
 }
 
-fun `builtin floor`(value: Float): Int {
+fun `builtin floor`(worldView: IWorldView, value: Float): Int {
     return Math.floor(value.toDouble()).toInt()
 }
 
-fun `builtin ceil`(value: Float): Int {
+fun `builtin ceil`(worldView: IWorldView, value: Float): Int {
     return Math.ceil(value.toDouble()).toInt()
 }
 
-fun `builtin root`(value: Float, root: Float): Float {
+fun `builtin root`(worldView: IWorldView, value: Float, root: Float): Float {
     return Math.pow(value.toDouble(), 1.0 / root).toFloat()
 }
 
-fun `builtin pow`(value: Float, exp: Float): Float {
+fun `builtin pow`(worldView: IWorldView, value: Float, exp: Float): Float {
     return Math.pow(value.toDouble(), exp.toDouble()).toFloat()
 }

--- a/compiler/runtime/src/main/kotlin/runtime/driver.kt
+++ b/compiler/runtime/src/main/kotlin/runtime/driver.kt
@@ -39,7 +39,7 @@ class MultiWorldView(private val world: World, private val dims: List<Int>, priv
         return if (overEdge) {
             edge
         } else {
-            world.getCell(*relPos.mapIndexed { index, p -> p wrap dims[index] }.toIntArray())
+            world.getCell(*relPos.mapIndexed { index, p -> (pos[index] + p) wrap dims[index] }.toIntArray())
         }
     }
 }

--- a/compiler/runtime/src/main/kotlin/runtime/graphics.kt
+++ b/compiler/runtime/src/main/kotlin/runtime/graphics.kt
@@ -12,9 +12,6 @@ class GraphicalDriver(private val worldConfig: WorldConfiguration, program: IPro
     override fun run() {
         assert(worldConfig.dims.size == 2)
 
-        val cellSize = worldConfig.cellSize
-        val tickrate = worldConfig.tickrate
-
         val frame = JFrame("Cellmata")
         val panel = frame.add(JPanel())
         panel.preferredSize = Dimension(
@@ -38,7 +35,7 @@ class GraphicalDriver(private val worldConfig: WorldConfiguration, program: IPro
                 update()
                 drawWorld(g)
             }
-        }, 0, (1000F / tickrate).toLong())
+        }, 0, (1000F / worldConfig.tickrate).toLong())
     }
 
     fun drawWorld(g: Graphics2D) {

--- a/compiler/runtime/src/main/kotlin/runtime/graphics.kt
+++ b/compiler/runtime/src/main/kotlin/runtime/graphics.kt
@@ -28,6 +28,9 @@ class GraphicalDriver(private val worldConfig: WorldConfiguration, program: IPro
         frame.isVisible = true
         val g = panel.graphics as Graphics2D
 
+        fillRandom(worldCurrent)
+        fillRandom(worldNext)
+
         drawWorld(g)
 
         Timer().scheduleAtFixedRate(object: TimerTask() {
@@ -50,6 +53,15 @@ class GraphicalDriver(private val worldConfig: WorldConfiguration, program: IPro
                     worldConfig.cellSize,
                     worldConfig.cellSize
                 )
+            }
+        }
+    }
+
+    fun fillRandom(world: World) {
+        val r = Random()
+        for (x in 0 until worldConfig.dims[0]) {
+            for (y in 0 until worldConfig.dims[1]) {
+                world.setCell(x,y, state = if(r.nextBoolean()) 1 else 0)
             }
         }
     }

--- a/compiler/src/main/kotlin/visitors/codegen.kt
+++ b/compiler/src/main/kotlin/visitors/codegen.kt
@@ -245,7 +245,7 @@ class KotlinCodegen : ASTVisitor<String> {
             fun baseMultiStateLookup(state: Int, index: Int): Int {
 
             if (index < 0) {
-            ${INDENT}throw Error()
+            ${INDENT}throw IndexOutOfBoundsException()
             }
 
             val baseId = baseStateLookup(state)
@@ -257,7 +257,7 @@ class KotlinCodegen : ASTVisitor<String> {
             builder.append("""
                 $INDENT$INDENT$baseId -> {
                 $INDENT$INDENT${INDENT}if(index >= ${it.multiStateCount}) {
-                $INDENT$INDENT$INDENT${INDENT}throw Error()
+                $INDENT$INDENT$INDENT${INDENT}throw IndexOutOfBoundsException()
                 $INDENT$INDENT}
                 $INDENT${INDENT}$baseId + index
                 $INDENT}

--- a/compiler/src/main/kotlin/visitors/codegen.kt
+++ b/compiler/src/main/kotlin/visitors/codegen.kt
@@ -681,9 +681,7 @@ class KotlinCodegen : ASTVisitor<String> {
         builder.append(getMappedLabel(node.ident))
         builder.append("(worldView")
         node.args.forEachIndexed { index, expr ->
-            if (index > 0) {
-                builder.append(", ")
-            }
+            builder.append(", ")
             builder.append(visit(expr))
         }
         builder.append("))")

--- a/compiler/src/main/kotlin/visitors/codegen.kt
+++ b/compiler/src/main/kotlin/visitors/codegen.kt
@@ -664,17 +664,18 @@ class KotlinCodegen : ASTVisitor<String> {
     }
 
     override fun visit(node: FuncCallExpr): String {
-        val builder = StringBuilder("(${getMappedLabel(node.ident)}(")
-
-        // Arguments
-        for ((i, arg) in node.args.withIndex()) {
-            if (i > 0) {
+        val builder = StringBuilder()
+        builder.append("(")
+        builder.append(getMappedLabel(node.ident))
+        builder.append("(worldView")
+        node.args.forEachIndexed { index, expr ->
+            if (index > 0) {
                 builder.append(", ")
             }
-            builder.append(visit(arg))
+            builder.append(visit(expr))
         }
-
         builder.append("))")
+
         return builder.toString()
     }
 

--- a/compiler/src/main/kotlin/visitors/codegen.kt
+++ b/compiler/src/main/kotlin/visitors/codegen.kt
@@ -23,6 +23,9 @@ class KotlinCodegenError_FoundUndeterminedType : KotlinCodegenError()
 
 class KotlinCodegenError_FoundNoSubtypeType : KotlinCodegenError()
 
+class KotlinCodegenError_Unreachable: KotlinCodegenError()
+
+
 class KotlinCodegen : ASTVisitor<String> {
     /**
      * String used for indentation in emitted code
@@ -419,7 +422,7 @@ class KotlinCodegen : ASTVisitor<String> {
 
     override fun visit(node: Coordinate): String {
         // Should be unreachable
-        TODO("not implemented")
+        throw KotlinCodegenError_Unreachable()
     }
 
     override fun visit(node: FuncDecl): String {
@@ -785,17 +788,17 @@ class KotlinCodegen : ASTVisitor<String> {
 
     override fun visit(node: FunctionArgument): String {
         // Should be unreachable
-        TODO("not implemented")
+        throw KotlinCodegenError_Unreachable()
     }
 
     override fun visit(node: WorldNode): String {
         // Should be unreachable
-        TODO("not implemented")
+        throw KotlinCodegenError_Unreachable()
     }
 
     override fun visit(node: WorldDimension): String {
         // Should be unreachable
-        TODO("not implemented")
+        throw KotlinCodegenError_Unreachable()
     }
 
     override fun visit(node: ForLoopStmt): String {

--- a/compiler/src/main/kotlin/visitors/codegen.kt
+++ b/compiler/src/main/kotlin/visitors/codegen.kt
@@ -183,6 +183,9 @@ class KotlinCodegen : ASTVisitor<String> {
         return builder.toString()
     }
 
+    /**
+     * Emit a function that given a state, return the id of base state for the mutltistate
+     */
     private fun emitBaseStateLookup(states: List<StateDecl>): String {
         val builder = StringBuilder()
 
@@ -206,6 +209,9 @@ class KotlinCodegen : ASTVisitor<String> {
         return builder.toString()
     }
 
+    /**
+     * Emit a function that given a state, return its index in its multistate
+     */
     private fun emitMultiStateIndexLookup(states: List<StateDecl>): String {
         val builder = StringBuilder()
 
@@ -229,6 +235,9 @@ class KotlinCodegen : ASTVisitor<String> {
         return builder.toString()
     }
 
+    /**
+     * Emit a function that given a multistate and a index in the in the multistate, returns the id of the concrete state from the given multistate
+     */
     private fun emitMultiStateLookup(states: List<StateDecl>): String {
         val builder = StringBuilder()
 

--- a/compiler/src/main/resources/osc.cell
+++ b/compiler/src/main/resources/osc.cell
@@ -1,0 +1,13 @@
+world {
+    size = 3 [wrap], 3 [wrap];
+    tickrate = 1;
+    cellsize = 10;
+}
+
+state s1 (255, 255, 255) {
+    become s2;
+}
+
+state s2 (0, 0, 0) {
+    become s1;
+}


### PR DESCRIPTION
Adds support for multistates in the Kotlin code generator. Also fixes functions not having any arguments, and several unreachable visitor functions having a TODO statement instead of a proper error.

This pull request depends on changes in #158 
Resolves #157 