### PR TITLE
Disallow function calls and neighbourhoods in constant declarations

### DIFF
--- a/compiler/src/main/kotlin/visitors/sanitychecker.kt
+++ b/compiler/src/main/kotlin/visitors/sanitychecker.kt
@@ -22,12 +22,11 @@ class DimensionsError(ctx: SourceContext, description: String) : CompileError(ct
  */
 class SanityChecker : BaseASTVisitor() {
 
-    var inAFunction = false
-    var inLimitedConstExpr = false // Constants are limited. Function calls are not allowed in limited expressions
-    var inAState = false
-    var numberOfStates = 0
-    var dimensions: Int = 0
-    var worldHasEdge = false
+    private var inAFunction = false
+    private var inAState = false
+    private var numberOfStates = 0
+    private var dimensions: Int = 0
+    private var worldHasEdge = false
 
     override fun visit(node: WorldNode) {
         dimensions = node.dimensions.size
@@ -69,23 +68,10 @@ class SanityChecker : BaseASTVisitor() {
         }
     }
 
-    override fun visit(node: ConstDecl) {
-        inLimitedConstExpr = true
-        super.visit(node)
-        inLimitedConstExpr = false
-    }
-
     override fun visit(node: FuncDecl) {
         inAFunction = true
         super.visit(node)
         inAFunction = false
-    }
-
-    override fun visit(node: FuncCallExpr) {
-        if (inLimitedConstExpr) {
-            ErrorLogger += SanityError(node.ctx, "Function calls are not allowed in constant declarations.")
-        }
-        super.visit(node)
     }
 
     override fun visit(node: Coordinate) {

--- a/compiler/src/main/kotlin/visitors/typechecker.kt
+++ b/compiler/src/main/kotlin/visitors/typechecker.kt
@@ -354,7 +354,12 @@ class TypeChecker(symbolTable: Table) : ScopedASTVisitor(symbolTable = symbolTab
             node.setType(
                 when (decl) {
                     is StateDecl -> StateType
-                    is NeighbourhoodDecl -> LocalNeighbourhoodType
+                    is NeighbourhoodDecl -> {
+                        if (inLimitedConstExpr) {
+                            ErrorLogger += TypeError(node.ctx, "Neighbourhoods are not allowed in constant declarations.")
+                        }
+                        LocalNeighbourhoodType
+                    }
                     is AssignStmt -> decl.expr.getType()
                     is ConstDecl -> decl.expr.getType()
                     is FunctionArgument -> decl.type

--- a/compiler/src/main/resources/non-compiling-programs/const-fun.cell
+++ b/compiler/src/main/resources/non-compiling-programs/const-fun.cell
@@ -1,0 +1,15 @@
+world {
+    size = 100 [wrap], 100 [wrap];
+    tickrate = 1;
+    cellsize = 5;
+}
+
+const c = 20 + foo(i)
+
+state alive (0, 0, 0) {
+
+}
+
+function foo(int i) int {
+    return i + i;
+}

--- a/compiler/src/main/resources/non-compiling-programs/const-ngbh.cell
+++ b/compiler/src/main/resources/non-compiling-programs/const-ngbh.cell
@@ -8,7 +8,7 @@ neighbourhood nei {
     (1, 0)
 }
 
-const c = alive == nei[0]
+const c = alive == nei[0];
 
 state alive (0, 0, 0) {
 

--- a/compiler/src/main/resources/non-compiling-programs/const-ngbh.cell
+++ b/compiler/src/main/resources/non-compiling-programs/const-ngbh.cell
@@ -1,0 +1,15 @@
+world {
+    size = 100 [wrap], 100 [wrap];
+    tickrate = 1;
+    cellsize = 5;
+}
+
+neighbourhood nei {
+    (1, 0)
+}
+
+const c = alive == nei[0]
+
+state alive (0, 0, 0) {
+
+}


### PR DESCRIPTION
Neighbourhoods (and functions since they can mention neighbourhoods) are not allowed in constants, as no cell is being evaluated.

Resolves #164 