### PR TITLE
Add missing semicolon in constant declaration

### DIFF
--- a/compiler/src/main/resources/non-compiling-programs/const-fun.cell
+++ b/compiler/src/main/resources/non-compiling-programs/const-fun.cell
@@ -4,7 +4,7 @@ world {
     cellsize = 5;
 }
 
-const c = 20 + foo(i)
+const c = 20 + foo(i);
 
 state alive (0, 0, 0) {
 


### PR DESCRIPTION
@NicEastvillage this seems to be something for you.