### PR TITLE
Rename project in settings.gradle to 'cellmata'

### DIFF
--- a/compiler/settings.gradle
+++ b/compiler/settings.gradle
@@ -1,3 +1,3 @@
-rootProject.name = 'cellumata'
+rootProject.name = 'cellmata'
 
 include 'runtime'


### PR DESCRIPTION
Minor, but makes jars correctly named.